### PR TITLE
mcp-client: add client-side auth

### DIFF
--- a/mcp-client-security/pom.xml
+++ b/mcp-client-security/pom.xml
@@ -93,6 +93,26 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-web-server</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/config/McpClientOAuth2Configurer.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/config/McpClientOAuth2Configurer.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.client.sync.config;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.security.client.sync.oauth2.metadata.McpMetadataDiscoveryService;
+import org.springaicommunity.mcp.security.client.sync.oauth2.registration.DynamicClientRegistrationRequest;
+import org.springaicommunity.mcp.security.client.sync.oauth2.registration.DynamicClientRegistrationService;
+import org.springaicommunity.mcp.security.client.sync.oauth2.registration.InMemoryMcpClientRegistrationRepository;
+import org.springaicommunity.mcp.security.client.sync.oauth2.registration.McpClientRegistrationRepository;
+
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2ClientConfigurer;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.endpoint.RestClientAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configurer for OAuth2 support for MCP clients.
+ *
+ * @author Daniel Garnier-Moiroux
+ */
+public class McpClientOAuth2Configurer extends AbstractHttpConfigurer<McpClientOAuth2Configurer, HttpSecurity> {
+
+	private static final Logger log = LoggerFactory.getLogger(McpClientOAuth2Configurer.class);
+
+	private Customizer<OAuth2ClientConfigurer<HttpSecurity>> oauth2ClientCustomizer = Customizer.withDefaults();
+
+	private final Map<String, String> mcpRegistrations = new HashMap<>();
+
+	@Nullable private String baseUrl = null;
+
+	private final boolean canListenForWebServerInitialized;
+
+	public McpClientOAuth2Configurer() {
+		this.canListenForWebServerInitialized = ClassUtils.isPresent(
+				"org.springframework.boot.web.server.servlet.context.ServletWebServerInitializedEvent",
+				getClass().getClassLoader());
+	}
+
+	@Override
+	public void init(HttpSecurity http) {
+		var clientRegistrationRepository = getClientRegistrationRepository(http);
+		registerMcpClients(http, clientRegistrationRepository);
+
+		http.oauth2Client(oauth2Client -> {
+			if (clientRegistrationRepository instanceof McpClientRegistrationRepository mcpClientRegistrationRepository) {
+				oauth2Client.authorizationCodeGrant(authorizationCode -> {
+					var authRequestResolver = new DefaultOAuth2AuthorizationRequestResolver(
+							mcpClientRegistrationRepository,
+							OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI);
+					authRequestResolver.setAuthorizationRequestCustomizer(
+							mcpAuthorizationRequestCustomizer(mcpClientRegistrationRepository));
+
+					authorizationCode.authorizationRequestResolver(authRequestResolver);
+					var tokenResponseClient = new RestClientAuthorizationCodeTokenResponseClient();
+					tokenResponseClient
+						.addParametersConverter(mcpTokenRequestParametersConverter(mcpClientRegistrationRepository));
+					authorizationCode.accessTokenResponseClient(tokenResponseClient);
+				});
+			}
+			else {
+				log.warn(
+						"ClientRegistrationRepository is not of type [{}]. Instead, found bean of type [{}]. Authorization and token requests will not include a \"resource=\" parameter.",
+						McpClientRegistrationRepository.class.getName(),
+						clientRegistrationRepository.getClass().getName());
+			}
+
+			oauth2ClientCustomizer.customize(oauth2Client);
+		});
+
+	}
+
+	/**
+	 * Customize the underlying Spring Security OAuth2 Client configuration, through an
+	 * {@link OAuth2ClientConfigurer}.
+	 * @param oauth2ClientCustomizer a customizer of OAuth2 Client. Defaults to a no-op
+	 * {@link Customizer#withDefaults()}
+	 * @return The {@link McpClientOAuth2Configurer} for further configuration
+	 */
+	public McpClientOAuth2Configurer oauth2Client(
+			Customizer<OAuth2ClientConfigurer<HttpSecurity>> oauth2ClientCustomizer) {
+		Assert.notNull(oauth2ClientCustomizer, "oauth2ClientCustomizer cannot be null");
+		this.oauth2ClientCustomizer = oauth2ClientCustomizer;
+		return this;
+	}
+
+	/**
+	 * Register OAuth2 Client for this given MCP Server. Note that, if no
+	 * {@link #baseUrl(String)} is set, the registration will happen only after the web
+	 * server starts. This is required to infer the correct base URL for all redirect URLs
+	 * when dynamically registering clients. This may lead to a race-condition if an MCP
+	 * Client is called before the dynamic clients are registered.
+	 * @param registrationId the id used for
+	 * {@link ClientRegistration#getRegistrationId()}
+	 * @param mcpServerUrl the URL of the MCP server
+	 * @return The {@link McpClientOAuth2Configurer} for further configuration
+	 */
+	public McpClientOAuth2Configurer registerMcpOAuth2Client(String registrationId, String mcpServerUrl) {
+		Assert.notNull(registrationId, "registration cannot be null");
+		Assert.notNull(mcpServerUrl, "mcpServerUrl cannot be null");
+		this.mcpRegistrations.put(registrationId, mcpServerUrl);
+		return this;
+	}
+
+	/**
+	 * The base URL to be used to construct redirect URIs for dynamically registered
+	 * clients. If not set, it will default to {@code http://localhost:{port}}.
+	 * @param baseUrl the base URL of the application
+	 * @return The {@link McpClientOAuth2Configurer} for further configuration
+	 */
+	public McpClientOAuth2Configurer baseUrl(String baseUrl) {
+		this.baseUrl = baseUrl;
+		return this;
+	}
+
+	private void registerMcpClients(HttpSecurity http, ClientRegistrationRepository repository) {
+		if (this.mcpRegistrations.isEmpty()) {
+			return;
+		}
+		if (!(repository instanceof McpClientRegistrationRepository mcpClientRegistrationRepo)) {
+			throw new IllegalStateException(
+					"You can only register OAuth2 Clients for MCP Servers with an McpClientRegistrationRepository. "
+							+ "Found a bean of type [%s] instead. ".formatted(repository.getClass().getName())
+							+ "Ensure Spring Boot is not auto-configuring a repository for you, either by disabling OAuth2ClientAutoConfiguration "
+							+ "or by not using spring.security.oauth2.client.registration.* properties. "
+							+ "Alternatively, consider providing your own McpClientRegistrationRepository bean.");
+		}
+		if (this.baseUrl != null) {
+			doRegisterMcpClients(mcpClientRegistrationRepo, this.baseUrl, this.mcpRegistrations);
+		}
+		else if (this.canListenForWebServerInitialized) {
+			var context = http.getSharedObject(ApplicationContext.class);
+			if (context instanceof ConfigurableApplicationContext configurableContext) {
+				registerClientsOnServerStartup(configurableContext, mcpClientRegistrationRepo, this.mcpRegistrations);
+			}
+			else {
+				throw new IllegalStateException(
+						"The application context is not an instance of ConfigurableApplicationContext. Instead, it is [%s]. Consider using a baseUrl instead of relying on server port auto-detection."
+							.formatted(context.getClass().getName()));
+			}
+		}
+		else {
+			throw new IllegalStateException(
+					"The application seems to not allow Spring Boot MVC application. Consider using a baseUrl instead of relying on server port auto-detection.");
+		}
+	}
+
+	private static void doRegisterMcpClients(McpClientRegistrationRepository repo, String baseUrl,
+			Map<String, String> registrations) {
+		for (var entry : registrations.entrySet()) {
+			var registration = DynamicClientRegistrationRequest.builder()
+				.grantTypes(List.of(AuthorizationGrantType.AUTHORIZATION_CODE))
+				.redirectUris(List.of(baseUrl + "/authorize/oauth2/code/" + entry.getKey()))
+				.build();
+			repo.registerMcpClient(entry.getKey(), entry.getValue(), registration);
+		}
+	}
+
+	private static Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> mcpTokenRequestParametersConverter(
+			McpClientRegistrationRepository mcpClientRegistrationRepository) {
+		return new McpTokenRequestParametersConverter(mcpClientRegistrationRepository);
+	}
+
+	private static Consumer<OAuth2AuthorizationRequest.Builder> mcpAuthorizationRequestCustomizer(
+			McpClientRegistrationRepository mcpClientRegistrationRepository) {
+		return req -> {
+			var baseRequest = req.build();
+			var registrationIdAttr = baseRequest.getAttributes().get(OAuth2ParameterNames.REGISTRATION_ID);
+			if (registrationIdAttr instanceof String registrationId) {
+				req.additionalParameters(params -> params.put("resource",
+						mcpClientRegistrationRepository.findResourceIdByRegistrationId(registrationId)));
+			}
+		};
+	}
+
+	private ClientRegistrationRepository getClientRegistrationRepository(HttpSecurity http) {
+		ClientRegistrationRepository clientRegistrationRepository = http
+			.getSharedObject(ClientRegistrationRepository.class);
+		if (clientRegistrationRepository == null) {
+			clientRegistrationRepository = getOptionalBean(http, ClientRegistrationRepository.class);
+			if (clientRegistrationRepository == null) {
+				clientRegistrationRepository = new InMemoryMcpClientRegistrationRepository(
+						getDynamicClientRegistrationService(http), getMcpMetadataDiscovery(http));
+			}
+			http.setSharedObject(ClientRegistrationRepository.class, clientRegistrationRepository);
+		}
+		return clientRegistrationRepository;
+	}
+
+	private McpMetadataDiscoveryService getMcpMetadataDiscovery(HttpSecurity http) {
+		McpMetadataDiscoveryService discovery = http.getSharedObject(McpMetadataDiscoveryService.class);
+		if (discovery == null) {
+			discovery = getOptionalBean(http, McpMetadataDiscoveryService.class);
+			if (discovery == null) {
+				discovery = new McpMetadataDiscoveryService();
+			}
+			http.setSharedObject(McpMetadataDiscoveryService.class, discovery);
+		}
+		return discovery;
+	}
+
+	private DynamicClientRegistrationService getDynamicClientRegistrationService(HttpSecurity http) {
+		DynamicClientRegistrationService clientRegistrationService = http
+			.getSharedObject(DynamicClientRegistrationService.class);
+		if (clientRegistrationService == null) {
+			clientRegistrationService = getOptionalBean(http, DynamicClientRegistrationService.class);
+			if (clientRegistrationService == null) {
+				clientRegistrationService = new DynamicClientRegistrationService();
+			}
+			http.setSharedObject(DynamicClientRegistrationService.class, clientRegistrationService);
+		}
+		return clientRegistrationService;
+	}
+
+	/**
+	 * Lifted from
+	 * {@code org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2ConfigurerUtils}.
+	 */
+	@Nullable private static <T> T getOptionalBean(HttpSecurity http, Class<T> type) {
+		Map<String, T> beansMap = BeanFactoryUtils
+			.beansOfTypeIncludingAncestors(http.getSharedObject(ApplicationContext.class), type);
+		if (beansMap.size() > 1) {
+			throw new NoUniqueBeanDefinitionException(type, beansMap.size(),
+					"Expected single matching bean of type '" + type.getName() + "' but found " + beansMap.size() + ": "
+							+ StringUtils.collectionToCommaDelimitedString(beansMap.keySet()));
+		}
+		return (!beansMap.isEmpty() ? beansMap.values().iterator().next() : null);
+	}
+
+	/**
+	 * Delay the registration of clients until the server has started. This allows us to
+	 * get the port of the running server for redirect urls.
+	 */
+	private static void registerClientsOnServerStartup(ConfigurableApplicationContext context,
+			McpClientRegistrationRepository repo, Map<String, String> registrations) {
+		context.addApplicationListener(event -> {
+			if (event instanceof org.springframework.boot.web.server.servlet.context.ServletWebServerInitializedEvent webServerEvent) {
+				var port = webServerEvent.getWebServer().getPort();
+				var baseUrl = "http://localhost:" + port;
+				doRegisterMcpClients(repo, baseUrl, registrations);
+			}
+		});
+	}
+
+	private static class McpTokenRequestParametersConverter
+			implements Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> {
+
+		private final McpClientRegistrationRepository mcpClientRegistrationRepository;
+
+		public McpTokenRequestParametersConverter(McpClientRegistrationRepository mcpClientRegistrationRepository) {
+			this.mcpClientRegistrationRepository = mcpClientRegistrationRepository;
+		}
+
+		@Override
+		public MultiValueMap<String, String> convert(OAuth2AuthorizationCodeGrantRequest source) {
+			var params = new LinkedMultiValueMap<String, String>();
+			var resource = mcpClientRegistrationRepository
+				.findResourceIdByRegistrationId(source.getClientRegistration().getRegistrationId());
+			if (resource != null) {
+				params.addIfAbsent("resource", resource);
+			}
+			return params;
+		}
+
+	}
+
+	public static McpClientOAuth2Configurer mcpClientOAuth2() {
+		return new McpClientOAuth2Configurer();
+	}
+
+}

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/config/package-info.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/config/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springaicommunity.mcp.security.client.sync.config;
+
+import org.jspecify.annotations.NullMarked;

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/metadata/McpMetadata.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/metadata/McpMetadata.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.client.sync.oauth2.metadata;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Aggregate metadata from the MCP Server.
+ */
+public record McpMetadata(@Nullable WwwAuthenticateParameters wwwAuthenticateParameters,
+		ProtectedResourceMetadata protectedResourceMetadata) {
+
+}

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/metadata/McpMetadataDiscoveryService.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/metadata/McpMetadataDiscoveryService.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.client.sync.oauth2.metadata;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Service to obtain metadata from an MCP server, from WWW-Authenticate headers on
+ * unauthorized calls and from OAuth2 Protected Resource Metadata endpoint.
+ * <p>
+ * Uses a RestClient internally to perform HTTP requests. By default, uses a new rest
+ * client with a Jackson JSON mapper.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc9728">RFC9728 - Protected
+ * Resource Metadata</a>
+ * @see <a href=
+ * "https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#protected-resource-metadata-discovery-requirements">MCP
+ * - Protected Resource Metadata Discovery Requirements</a>
+ */
+public class McpMetadataDiscoveryService {
+
+	private static final Logger log = LoggerFactory.getLogger(McpMetadataDiscoveryService.class);
+
+	private final RestClient restClient;
+
+	public McpMetadataDiscoveryService() {
+		this.restClient = RestClient.builder()
+			.configureMessageConverters((converters) -> converters.registerDefaults()
+				.withJsonConverter(new JacksonJsonHttpMessageConverter(JsonMapper.builder()
+					.propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+					.changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL)))))
+			.build();
+	}
+
+	public McpMetadataDiscoveryService(RestClient restClient) {
+		this.restClient = restClient;
+	}
+
+	/**
+	 * Get metadata from the WWW-authenticate header on an unauthorized request.
+	 */
+	@Nullable public WwwAuthenticateParameters getWwwAuthenticateParameters(String serverUrl) {
+		log.debug("Getting www-authenticate parameter");
+		try {
+			log.debug("Getting WWW-authenticate header for {}", serverUrl);
+			this.restClient.post().uri(serverUrl).retrieve().toBodilessEntity();
+		}
+		catch (HttpClientErrorException.Unauthorized unauthorized) {
+			var headers = unauthorized.getResponseHeaders();
+			if (headers == null) {
+				return null;
+			}
+			var authenticateHeader = headers.getFirst("www-authenticate");
+			if (authenticateHeader == null) {
+				log.debug("No WWW-authenticate header");
+				return null;
+			}
+			log.debug("Got WWW-authenticate={}", authenticateHeader);
+			var protectedResourceMetadataUrl = extractWwwAuthenticateParameters("resource_metadata",
+					authenticateHeader);
+			if (protectedResourceMetadataUrl == null) {
+				return null;
+			}
+			var scope = extractWwwAuthenticateParameters("scope", authenticateHeader);
+			var authenticateParams = new WwwAuthenticateParameters(protectedResourceMetadataUrl, scope);
+			log.debug("Got www-authenticate parameters {}", authenticateParams);
+			return authenticateParams;
+		}
+		log.debug("Could not get www-authenticate parameters");
+		return null;
+	}
+
+	/**
+	 * Get full MCP Server metadata, both from the WWW-Authenticate header and from the
+	 * Protected Resource Metadata document.
+	 */
+	public McpMetadata getMcpMetadata(String mcpServerUrl) {
+		var wwwAuthenticateParameters = getWwwAuthenticateParameters(mcpServerUrl);
+		var candidateUrls = new ArrayList<String>();
+		if (wwwAuthenticateParameters != null) {
+			candidateUrls.add(wwwAuthenticateParameters.resourceMetadata());
+		}
+		candidateUrls.add(computeWellKnownProtectedResourceUrl(mcpServerUrl, true));
+		candidateUrls.add(computeWellKnownProtectedResourceUrl(mcpServerUrl, false));
+		var protectedResourceMetadata = getProtectedResourceMetadata(candidateUrls);
+		if (!mcpServerUrl.startsWith(protectedResourceMetadata.resource())) {
+			throw new IllegalStateException("Resource identifier [%s] does not match MCP Server url [%s]"
+				.formatted(protectedResourceMetadata.resource(), mcpServerUrl));
+		}
+		return new McpMetadata(wwwAuthenticateParameters, protectedResourceMetadata);
+	}
+
+	/**
+	 * Get Protected Resource Metadata document.
+	 * @param resourceMetadataUrlCandidates The URLs from which to fetch the document
+	 * @return The Protected Resource Metadata document
+	 */
+	public ProtectedResourceMetadata getProtectedResourceMetadata(Collection<String> resourceMetadataUrlCandidates) {
+		for (var protectedResourceMetadataUrl : resourceMetadataUrlCandidates) {
+			try {
+				log.debug("Reading protected resource metadata [{}]", protectedResourceMetadataUrl);
+				var prm = restClient.get()
+					.uri(protectedResourceMetadataUrl)
+					.retrieve()
+					.body(ProtectedResourceMetadata.class);
+				if (prm == null) {
+					continue;
+				}
+				log.debug("Got Protected Resource Metadata: {}", prm);
+				return prm;
+			}
+			catch (HttpClientErrorException.NotFound | HttpClientErrorException.Unauthorized ignored) {
+				// ignored
+			}
+		}
+		throw new IllegalStateException("Could not find protected resource metadata");
+	}
+
+	private String computeWellKnownProtectedResourceUrl(String mcpServerUrl, boolean includePath) {
+		var path = "";
+		if (includePath) {
+			var url = UriComponentsBuilder.fromUriString(mcpServerUrl).build();
+			if (url.getPath() != null) {
+				path = url.getPath();
+			}
+		}
+		var prmUrl = UriComponentsBuilder.fromUriString(mcpServerUrl)
+			.replacePath("/.well-known/oauth-protected-resource" + path)
+			.toUriString();
+		return prmUrl;
+	}
+
+	@Nullable private static String extractWwwAuthenticateParameters(String parameterName, String authenticateHeader) {
+		var pattern = Pattern.compile(parameterName + "=(?:\"([^\"]+)\"|([^\\s,]+))");
+		var matcher = pattern.matcher(authenticateHeader);
+		if (matcher.find()) {
+			return matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+		}
+		return null;
+	}
+
+}

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/metadata/ProtectedResourceMetadata.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/metadata/ProtectedResourceMetadata.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.client.sync.oauth2.metadata;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The response for an OAuth2 Protected Resource Metadata request.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @see <a href=
+ * "https://datatracker.ietf.org/doc/html/rfc9728#name-protected-resource-metadata-r">RFC9728
+ * OAuth 2.0 Protected Resource Metadata</a>
+ */
+public record ProtectedResourceMetadata(String resource, @Nullable List<String> authorizationServers,
+		@Nullable List<String> scopesSupported) {
+
+}

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/metadata/WwwAuthenticateParameters.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/metadata/WwwAuthenticateParameters.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.client.sync.oauth2.metadata;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Parameters from a WWW-Authenticate header for OAuth2 Protected Resources.
+ *
+ * @author Daniel Garnier-Moiroux
+ */
+public record WwwAuthenticateParameters(String resourceMetadata, @Nullable String scope) {
+
+}

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/metadata/package-info.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/metadata/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springaicommunity.mcp.security.client.sync.oauth2.metadata;
+
+import org.jspecify.annotations.NullMarked;

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DynamicClientRegistrationRequest.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DynamicClientRegistrationRequest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.client.sync.oauth2.registration;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponseType;
+import org.springframework.util.Assert;
+
+/**
+ * Represents a base request for OAuth2 Dynamic Client registration.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7591#section-3.1">RFC7591 - 3.1
+ * Client Registration Request</a>
+ */
+public class DynamicClientRegistrationRequest {
+
+	private final List<AuthorizationGrantType> grantTypes;
+
+	@Nullable private final List<String> redirectUris;
+
+	@Nullable private final ClientAuthenticationMethod tokenEndpointAuthMethod;
+
+	@Nullable private final List<OAuth2AuthorizationResponseType> responseTypes;
+
+	@Nullable private final String clientName;
+
+	@Nullable private final String clientUri;
+
+	@Nullable private final String scope;
+
+	private DynamicClientRegistrationRequest(List<AuthorizationGrantType> grantTypes,
+			@Nullable List<String> redirectUris, @Nullable ClientAuthenticationMethod tokenEndpointAuthMethod,
+			@Nullable List<OAuth2AuthorizationResponseType> responseTypes, @Nullable String clientName,
+			@Nullable String clientUri, @Nullable String scope) {
+		this.grantTypes = Collections.unmodifiableList(grantTypes);
+		this.redirectUris = redirectUris != null ? Collections.unmodifiableList(redirectUris) : null;
+		this.responseTypes = responseTypes != null ? Collections.unmodifiableList(responseTypes) : null;
+		this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+		this.clientName = clientName;
+		this.clientUri = clientUri;
+		this.scope = scope;
+	}
+
+	public List<AuthorizationGrantType> getGrantTypes() {
+		return this.grantTypes;
+	}
+
+	@Nullable public List<String> getRedirectUris() {
+		return this.redirectUris;
+	}
+
+	@Nullable public ClientAuthenticationMethod getTokenEndpointAuthMethod() {
+		return this.tokenEndpointAuthMethod;
+	}
+
+	@Nullable public List<OAuth2AuthorizationResponseType> getResponseTypes() {
+		return this.responseTypes;
+	}
+
+	@Nullable public String getClientName() {
+		return this.clientName;
+	}
+
+	@Nullable public String getClientUri() {
+		return this.clientUri;
+	}
+
+	@Nullable public String getScope() {
+		return this.scope;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static Builder from(DynamicClientRegistrationRequest other) {
+		Assert.notNull(other, "source request must not be null");
+		Builder builder = new Builder();
+		builder.grantTypes = other.grantTypes;
+		builder.redirectUris = other.redirectUris;
+		builder.tokenEndpointAuthMethod = other.tokenEndpointAuthMethod;
+		builder.responseTypes = other.responseTypes;
+		builder.clientName = other.clientName;
+		builder.clientUri = other.clientUri;
+		builder.scope = other.scope;
+		return builder;
+	}
+
+	@Override
+	public String toString() {
+		return "DynamicClientRegistrationRequest{" + "grantTypes=" + grantTypes + ", redirectUris=" + redirectUris
+				+ ", tokenEndpointAuthMethod=" + tokenEndpointAuthMethod + ", responseTypes=" + responseTypes
+				+ ", clientName='" + clientName + '\'' + ", clientUri='" + clientUri + '\'' + ", scope='" + scope + '\''
+				+ '}';
+	}
+
+	public static class Builder {
+
+		@Nullable private List<AuthorizationGrantType> grantTypes;
+
+		@Nullable private List<String> redirectUris;
+
+		@Nullable private ClientAuthenticationMethod tokenEndpointAuthMethod;
+
+		@Nullable private List<OAuth2AuthorizationResponseType> responseTypes;
+
+		@Nullable private String clientName;
+
+		@Nullable private String clientUri;
+
+		@Nullable private String scope;
+
+		private Builder() {
+		}
+
+		public Builder redirectUris(List<String> redirectUris) {
+			this.redirectUris = redirectUris;
+			return this;
+		}
+
+		public Builder grantTypes(List<AuthorizationGrantType> grantTypes) {
+			Assert.notEmpty(grantTypes, "grantTypes cannot be empty");
+			this.grantTypes = grantTypes;
+			return this;
+		}
+
+		public Builder tokenEndpointAuthMethod(ClientAuthenticationMethod tokenEndpointAuthMethod) {
+			this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+			return this;
+		}
+
+		public Builder responseTypes(List<OAuth2AuthorizationResponseType> responseTypes) {
+			this.responseTypes = responseTypes;
+			return this;
+		}
+
+		public Builder clientName(String clientName) {
+			this.clientName = clientName;
+			return this;
+		}
+
+		public Builder clientUri(String clientUri) {
+			this.clientUri = clientUri;
+			return this;
+		}
+
+		public Builder scope(List<String> scopes) {
+			Assert.notNull(scopes, "scope cannot be null");
+			this.scope = String.join(" ", scopes);
+			return this;
+		}
+
+		public Builder scope(String scope) {
+			this.scope = scope;
+			return this;
+		}
+
+		public DynamicClientRegistrationRequest build() {
+			if (this.grantTypes == null) {
+				this.grantTypes = List.of(AuthorizationGrantType.CLIENT_CREDENTIALS);
+			}
+			if (this.grantTypes.contains(AuthorizationGrantType.AUTHORIZATION_CODE)) {
+				Assert.notEmpty(this.redirectUris,
+						"redirectUris must not be null or empty when grant type contains authorization_code");
+				if (this.responseTypes == null) {
+					this.responseTypes = List.of(OAuth2AuthorizationResponseType.CODE);
+				}
+			}
+			if (this.grantTypes.contains(AuthorizationGrantType.REFRESH_TOKEN)) {
+				Assert.isTrue(this.grantTypes.contains(AuthorizationGrantType.AUTHORIZATION_CODE),
+						"grant types must contain authorization_code when refresh_token is present");
+			}
+			return new DynamicClientRegistrationRequest(this.grantTypes, this.redirectUris,
+					this.tokenEndpointAuthMethod, this.responseTypes, this.clientName, this.clientUri, this.scope);
+		}
+
+	}
+
+}

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DynamicClientRegistrationResponse.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DynamicClientRegistrationResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.client.sync.oauth2.registration;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents the response for OAuth2 Dynamic Client registration request.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1">RFC7591 -
+ * 3.2.1 Client information response</a>
+ */
+public record DynamicClientRegistrationResponse(
+		// Required
+		String clientId,
+		// Optional credentials
+		@Nullable String clientSecret, @Nullable Instant clientIdIssuedAt, @Nullable Instant clientSecretExpiresAt,
+		// Client metadata (Section 2)
+		@Nullable List<String> redirectUris, @Nullable String tokenEndpointAuthMethod,
+		@Nullable List<String> grantTypes, @Nullable List<String> responseTypes, @Nullable String clientName,
+		@Nullable String scope, @Nullable String jwksUri) {
+}

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DynamicClientRegistrationService.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DynamicClientRegistrationService.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.client.sync.oauth2.registration;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.security.oauth2.client.registration.ClientRegistrations;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Service to perform OAuth2 Dynamic Client Registration. It expects an open registration
+ * endpoint, with no authentication.
+ * <p>
+ * Uses a RestClient internally to perform HTTP requests. By default, uses a new rest
+ * client with a Jackson JSON mapper.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7591">RFC7591 - OAuth 2.0
+ * Dynamic Client Registration Protocol</a>
+ */
+public class DynamicClientRegistrationService {
+
+	private final RestClient restClient;
+
+	public DynamicClientRegistrationService() {
+		this.restClient = RestClient.builder()
+			.configureMessageConverters((converters) -> converters.registerDefaults()
+				.withJsonConverter(new JacksonJsonHttpMessageConverter(JsonMapper.builder()
+					.propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+					.changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL)))))
+			.build();
+	}
+
+	public DynamicClientRegistrationService(RestClient restClient) {
+		this.restClient = restClient;
+	}
+
+	public DynamicClientRegistrationResponse register(DynamicClientRegistrationRequest registrationRequest,
+			String authServerUrl) {
+		var registrationEndpoint = findRegistrationEndpoint(authServerUrl);
+		var registrationResponse = restClient.post()
+			.uri(registrationEndpoint)
+			.contentType(MediaType.APPLICATION_JSON)
+			.body(registrationRequest)
+			.retrieve()
+			.body(DynamicClientRegistrationResponse.class);
+		if (registrationResponse == null) {
+			throw new IllegalStateException("Cannot register client");
+		}
+		return registrationResponse;
+	}
+
+	private String findRegistrationEndpoint(String authServerUrl) {
+		var builder = ClientRegistrations.fromIssuerLocation(authServerUrl).clientId("~~~~ignored~~~~").build();
+		var registrationEndpoint = builder.getProviderDetails().getConfigurationMetadata().get("registration_endpoint");
+		if (registrationEndpoint == null) {
+			throw new IllegalStateException(
+					"No registration endpoint found for auth server [%s]".formatted(authServerUrl));
+		}
+		return registrationEndpoint.toString();
+	}
+
+}

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/InMemoryMcpClientRegistrationRepository.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/InMemoryMcpClientRegistrationRepository.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.client.sync.oauth2.registration;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jspecify.annotations.Nullable;
+import org.springaicommunity.mcp.security.client.sync.oauth2.metadata.McpMetadata;
+import org.springaicommunity.mcp.security.client.sync.oauth2.metadata.McpMetadataDiscoveryService;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrations;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * In-memory implementation of {@link McpClientRegistrationRepository} that supports
+ * dynamic client registration as well as pre-registered clients.
+ * <p>
+ * For dynamic client registration, it first discovers metadata about the MCP Server,
+ * including auth server location and required scopes, and then performs registration.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @see <a href=
+ * "https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization">MCP -
+ * Authorization</a>
+ */
+public class InMemoryMcpClientRegistrationRepository implements McpClientRegistrationRepository {
+
+	private final Map<String, ClientRegistration> registrations = new ConcurrentHashMap<>();
+
+	private final Map<String, String> resources = new ConcurrentHashMap<>();
+
+	private final DynamicClientRegistrationService clientRegistrationService;
+
+	private final McpMetadataDiscoveryService discovery;
+
+	public InMemoryMcpClientRegistrationRepository(DynamicClientRegistrationService clientRegistrationService,
+			McpMetadataDiscoveryService discovery) {
+		this.clientRegistrationService = clientRegistrationService;
+		this.discovery = discovery;
+	}
+
+	@Override
+	public void registerMcpClient(String registrationId, String mcpServerUrl,
+			DynamicClientRegistrationRequest registrationRequest) {
+		this.registrations.computeIfAbsent(registrationId, id -> {
+			var mcpMetadata = this.discovery.getMcpMetadata(mcpServerUrl);
+			Assert.notNull(mcpMetadata.protectedResourceMetadata().authorizationServers(),
+					"cannot find authorization_servers from MCP Server's protected resource metadata");
+			var issuerUrl = mcpMetadata.protectedResourceMetadata().authorizationServers().get(0);
+			var finalRegistrationRequest = updateScopes(registrationRequest, mcpMetadata);
+			var registrationResponse = this.clientRegistrationService.register(finalRegistrationRequest, issuerUrl);
+			var clientRegistration = toClientRegistration(registrationId, issuerUrl, finalRegistrationRequest,
+					registrationResponse);
+			this.resources.put(id, mcpMetadata.protectedResourceMetadata().resource());
+			return clientRegistration;
+		});
+	}
+
+	@Override
+	public void addPreRegisteredClient(ClientRegistration clientRegistration, String resourceId) {
+		this.registrations.computeIfAbsent(clientRegistration.getRegistrationId(), id -> {
+			this.resources.put(id, resourceId);
+			return clientRegistration;
+		});
+	}
+
+	@Override
+	@Nullable public String findResourceIdByRegistrationId(String registrationId) {
+		return this.resources.get(registrationId);
+	}
+
+	@Override
+	@Nullable public ClientRegistration findByRegistrationId(String registrationId) {
+		return this.registrations.get(registrationId);
+	}
+
+	private DynamicClientRegistrationRequest updateScopes(DynamicClientRegistrationRequest originalRequest,
+			McpMetadata mcpMetadata) {
+		if (StringUtils.hasText(originalRequest.getScope())) {
+			return originalRequest;
+		}
+
+		if (mcpMetadata.wwwAuthenticateParameters() != null
+				&& StringUtils.hasText(mcpMetadata.wwwAuthenticateParameters().scope())) {
+
+			return DynamicClientRegistrationRequest.from(originalRequest)
+				.scope(mcpMetadata.wwwAuthenticateParameters().scope())
+				.build();
+		}
+		else if (!CollectionUtils.isEmpty(mcpMetadata.protectedResourceMetadata().scopesSupported())) {
+
+			return DynamicClientRegistrationRequest.from(originalRequest)
+				.scope(mcpMetadata.protectedResourceMetadata().scopesSupported())
+				.build();
+		}
+
+		return originalRequest;
+	}
+
+	private static ClientRegistration toClientRegistration(String registrationId, String issuerUrl,
+			DynamicClientRegistrationRequest registrationRequest,
+			DynamicClientRegistrationResponse registrationResponse) {
+		// Slight inefficiency, as we are already fetching
+		// /.well-known/oauth-authorization-server from the auth server in the
+		// dynamic client registration service
+		// Note that this may fail if the auth server is not reachable, but dynamic client
+		// registration will fail in that case anyway.
+		ClientRegistration.Builder registrationBuilder = ClientRegistrations.fromIssuerLocation(issuerUrl)
+			.registrationId(registrationId);
+		registrationBuilder.clientId(registrationResponse.clientId());
+
+		if (registrationResponse.clientSecret() != null) {
+			registrationBuilder.clientSecret(registrationResponse.clientSecret());
+		}
+
+		if (registrationResponse.tokenEndpointAuthMethod() != null) {
+			registrationBuilder.clientAuthenticationMethod(
+					new ClientAuthenticationMethod(registrationResponse.tokenEndpointAuthMethod()));
+		}
+		else if (registrationRequest.getTokenEndpointAuthMethod() != null) {
+			registrationBuilder.clientAuthenticationMethod(registrationRequest.getTokenEndpointAuthMethod());
+		}
+
+		if (registrationResponse.grantTypes() != null && !registrationResponse.grantTypes().isEmpty()) {
+			registrationBuilder
+				.authorizationGrantType(new AuthorizationGrantType(registrationResponse.grantTypes().get(0)));
+		}
+		else if (!registrationRequest.getGrantTypes().isEmpty()) {
+			registrationBuilder.authorizationGrantType(registrationRequest.getGrantTypes().get(0));
+		}
+		else {
+			registrationBuilder.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS);
+		}
+
+		if (registrationResponse.redirectUris() != null && !registrationResponse.redirectUris().isEmpty()) {
+			registrationBuilder.redirectUri(registrationResponse.redirectUris().get(0));
+		}
+		else if (registrationRequest.getRedirectUris() != null && !registrationRequest.getRedirectUris().isEmpty()) {
+			registrationBuilder.redirectUri(registrationRequest.getRedirectUris().get(0));
+		}
+
+		if (StringUtils.hasText(registrationResponse.scope())) {
+			registrationBuilder.scope(registrationResponse.scope().split(" "));
+		}
+		else if (StringUtils.hasText(registrationRequest.getScope())) {
+			registrationBuilder.scope(registrationRequest.getScope().split(" "));
+		}
+
+		if (registrationResponse.clientName() != null) {
+			registrationBuilder.clientName(registrationResponse.clientName());
+		}
+		else if (registrationRequest.getClientName() != null) {
+			registrationBuilder.clientName(registrationRequest.getClientName());
+		}
+
+		return registrationBuilder.build();
+	}
+
+}

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/McpClientRegistrationRepository.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/McpClientRegistrationRepository.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.client.sync.oauth2.registration;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+/**
+ * A {@link ClientRegistrationRepository} tailored for MCP use-cases.
+ *
+ * @author Daniel Garnier-Moiroux
+ */
+public interface McpClientRegistrationRepository extends ClientRegistrationRepository {
+
+	/**
+	 * Register a client with the given MCP server. This discovers the MCP configuration,
+	 * including resource identifier, supported scopes and associated authorization
+	 * server.
+	 * @param registrationId the Client's internal registration ID
+	 * @param mcpServerUrl the URL of the server holding the metadata
+	 * @param registrationRequest the base registration request to be used to specify
+	 * parameters in the registration request
+	 */
+	void registerMcpClient(String registrationId, String mcpServerUrl,
+			DynamicClientRegistrationRequest registrationRequest);
+
+	/**
+	 * Add an existing, pre-registered client to the repository.
+	 * @param clientRegistration the client
+	 * @param resourceId the MCP server's associated resource ID
+	 */
+	void addPreRegisteredClient(ClientRegistration clientRegistration, String resourceId);
+
+	/**
+	 * Find the associated resource identifier for the given registration.
+	 * @param registrationId the registration ID
+	 * @return the resource identifier
+	 */
+	@Nullable String findResourceIdByRegistrationId(String registrationId);
+
+}

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/package-info.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springaicommunity.mcp.security.client.sync.oauth2.registration;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
This is a first stab at client-side Dynamic Client Registration. It still has rough edges and needs extensive testing. It will be released later to support conformance testing.

Expect further improvements and very likely breaking API changes.

Closes #3 .