### PR TITLE
authorization-server: apply McpAuthorizationServer#authorizationServer(...) multiple times

### DIFF
--- a/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationServerConfigurer.java
+++ b/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationServerConfigurer.java
@@ -16,6 +16,8 @@
 
 package org.springaicommunity.mcp.security.authorizationserver.config;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import com.nimbusds.jose.jwk.source.JWKSource;
@@ -49,7 +51,7 @@ import org.springframework.util.StringUtils;
 public class McpAuthorizationServerConfigurer
 		extends AbstractHttpConfigurer<McpAuthorizationServerConfigurer, HttpSecurity> {
 
-	private Customizer<OAuth2AuthorizationServerConfigurer> authServerCustomizer = Customizer.withDefaults();
+	private final List<Customizer<OAuth2AuthorizationServerConfigurer>> authServerCustomizer = new ArrayList<>();
 
 	private boolean supportDynamicClientRegistration = true;
 
@@ -68,7 +70,7 @@ public class McpAuthorizationServerConfigurer
 			Customizer<OAuth2AuthorizationServerConfigurer> oauth2AuthorizationServerConfigurerCustomizer) {
 		Assert.notNull(oauth2AuthorizationServerConfigurerCustomizer,
 				"oauth2AuthorizationServerConfigurerCustomizer cannot be null");
-		this.authServerCustomizer = oauth2AuthorizationServerConfigurerCustomizer;
+		this.authServerCustomizer.add(oauth2AuthorizationServerConfigurerCustomizer);
 		return this;
 	}
 
@@ -96,7 +98,7 @@ public class McpAuthorizationServerConfigurer
 			if (this.supportDynamicClientRegistration) {
 				authServer.clientRegistrationEndpoint(cr -> cr.openRegistrationAllowed(true));
 			}
-			this.authServerCustomizer.customize(authServer);
+			this.authServerCustomizer.forEach(c -> c.customize(authServer));
 		});
 
 		// This makes Spring servers happy by ensuring that

--- a/mcp-authorization-server/src/test/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationServerConfigurerTest.java
+++ b/mcp-authorization-server/src/test/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationServerConfigurerTest.java
@@ -1,6 +1,7 @@
 package org.springaicommunity.mcp.security.authorizationserver.config;
 
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import com.nimbusds.jose.jwk.source.JWKSource;
@@ -89,6 +90,13 @@ class McpAuthorizationServerConfigurerTest {
 		assertThat(resp.getResponse().getStatus()).isEqualTo(201);
 	}
 
+	@Test
+	void stackingAuthzServerCustomizers() {
+		var authzServerCustomizerCalled = wac.getBean("authzServerCustomizationCount", AtomicInteger.class);
+
+		assertThat(authzServerCustomizerCalled.get()).isEqualTo(2);
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@EnableWebMvc
 	@EnableWebSecurity
@@ -98,15 +106,22 @@ class McpAuthorizationServerConfigurerTest {
 				"0558BC36-378D-4809-A551-E61F3B8894B9-8ECA8B16-D07E-4856-9564-50637494E51A".getBytes());
 
 		@Bean
-		SecurityFilterChain filterChain(HttpSecurity http) {
+		AtomicInteger authzServerCustomizationCount() {
+			return new AtomicInteger(0);
+		}
+
+		@Bean
+		SecurityFilterChain filterChain(HttpSecurity http, AtomicInteger authzServerCustomizationCount) {
 			http.authorizeHttpRequests(authz -> authz.anyRequest().authenticated())
 				.formLogin(Customizer.withDefaults())
 				.with(mcpAuthorizationServer(), mcpAuthzServer -> {
 					mcpAuthzServer.dynamicClientRegistration(true);
+					mcpAuthzServer.authorizationServer(authzServer -> authzServerCustomizationCount.incrementAndGet());
 					mcpAuthzServer.authorizationServer(authzServer -> {
 						// usually provided as a Boot bean from properties
 						authzServer.authorizationServerSettings(AuthorizationServerSettings.builder().build());
 					});
+					mcpAuthzServer.authorizationServer(authzServer -> authzServerCustomizationCount.incrementAndGet());
 				});
 			return http.build();
 		}


### PR DESCRIPTION
Calling `McpAuthorizationServer.authorizationServer(...)` with a customizer used to only apply a single customizer instead of applying everything the user registers. This was a problem when they wanted to augment the default auto-configuration with their own config