### PR TITLE
mcp-server: return 401 when API key is missing

### DIFF
--- a/mcp-server-security/src/main/java/org/springaicommunity/mcp/security/server/config/McpApiKeyConfigurer.java
+++ b/mcp-server-security/src/main/java/org/springaicommunity/mcp/security/server/config/McpApiKeyConfigurer.java
@@ -23,12 +23,14 @@ import org.springaicommunity.mcp.security.server.apikey.authentication.ApiKeyAut
 import org.springaicommunity.mcp.security.server.apikey.web.ApiKeyAuthenticationConverter;
 import org.springaicommunity.mcp.security.server.apikey.web.ApiKeyAuthenticationFilter;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -50,6 +52,7 @@ public class McpApiKeyConfigurer extends AbstractHttpConfigurer<McpApiKeyConfigu
 	public void init(HttpSecurity http) {
 		Assert.notNull(this.apiKeyEntityRepository, "apiKeyRepository cannot be null");
 		http.authenticationProvider(postProcess(new ApiKeyAuthenticationProvider<>(this.apiKeyEntityRepository)));
+		http.exceptionHandling(e -> e.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
 		registerCsrfOverride(http);
 		if (this.sessionBindingConfigurer != null) {
 			this.sessionBindingConfigurer.init(http);

--- a/mcp-server-security/src/test/java/org/springaicommunity/mcp/security/server/config/McpApiKeyConfigurerTest.java
+++ b/mcp-server-security/src/test/java/org/springaicommunity/mcp/security/server/config/McpApiKeyConfigurerTest.java
@@ -77,10 +77,10 @@ class McpApiKeyConfigurerTest {
 	}
 
 	@Test
-	void noApiKeyForbidden() {
+	void noApiKeyReturns401() {
 		var resp = this.mvc.get().uri("/default");
 
-		assertThat(resp).hasStatus(HttpStatus.FORBIDDEN);
+		assertThat(resp).hasStatus(HttpStatus.UNAUTHORIZED);
 	}
 
 	@Test

--- a/mcp-server-security/src/test/java/org/springaicommunity/mcp/security/server/config/McpApiKeyConfigurerTest.java
+++ b/mcp-server-security/src/test/java/org/springaicommunity/mcp/security/server/config/McpApiKeyConfigurerTest.java
@@ -21,12 +21,14 @@ import org.springaicommunity.mcp.security.server.apikey.web.ApiKeyAuthentication
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ContextConfiguration;
@@ -39,7 +41,9 @@ import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.RouterFunctions;
 import org.springframework.web.servlet.function.ServerResponse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.springaicommunity.mcp.security.server.config.McpApiKeyConfigurer.mcpServerApiKey;
+import static org.springaicommunity.mcp.security.server.config.McpServerOAuth2Configurer.mcpServerOAuth2;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
@@ -129,6 +133,13 @@ class McpApiKeyConfigurerTest {
 	}
 
 	@Test
+	void noCredentialsWithOAuth2AlsoConfiguredThenWwwAuthenticate() {
+		assertThat(this.mvc.get().uri("/combined")).hasStatus(HttpStatus.UNAUTHORIZED)
+			.headers()
+			.containsHeader(HttpHeaders.WWW_AUTHENTICATE);
+	}
+
+	@Test
 	void sessionBindingEnforced() {
 		var sessionId = java.util.UUID.randomUUID().toString();
 		var initializeRequest = this.mvc.get()
@@ -198,6 +209,17 @@ class McpApiKeyConfigurerTest {
 					}
 					return ApiKeyAuthenticationToken.unauthenticated(ApiKeyImpl.from(extractedKey));
 				}))
+				.build();
+		}
+
+		@Bean
+		SecurityFilterChain combinedApiKeyAndOAuth2SecurityFilterChain(HttpSecurity http) throws Exception {
+			return http.securityMatcher("/combined/**")
+				.authorizeHttpRequests(authz -> authz.anyRequest().authenticated())
+				.with(mcpServerApiKey(), apiKey -> apiKey.apiKeyRepository(repo()))
+				.with(mcpServerOAuth2(),
+						oauth2 -> oauth2.authorizationServer("https://test-issuer.example.com")
+							.jwtDecoder(mock(JwtDecoder.class)))
 				.build();
 		}
 


### PR DESCRIPTION
Fixes #46

Currently, when an API key is missing, the server returns 403 Forbidden.
This change configures an `HttpStatusEntryPoint` with `UNAUTHORIZED (401)`,
which is the correct HTTP status when authentication is missing.