### PR TITLE
mcp-server: return 401 when API key is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ class McpServerConfiguration {
 ```
 
 Then you should be able to call your MCP server with a header `X-API-key: api01.mycustomapikey`.
+Requests without an API key receive an HTTP 401 response when no other configured authentication mechanism
+authenticates the request. Requests containing an invalid API key also receive an HTTP 401 response.
 
 ### Known limitations
 

--- a/mcp-server-security/src/main/java/org/springaicommunity/mcp/security/server/config/McpApiKeyConfigurer.java
+++ b/mcp-server-security/src/main/java/org/springaicommunity/mcp/security/server/config/McpApiKeyConfigurer.java
@@ -23,12 +23,14 @@ import org.springaicommunity.mcp.security.server.apikey.authentication.ApiKeyAut
 import org.springaicommunity.mcp.security.server.apikey.web.ApiKeyAuthenticationConverter;
 import org.springaicommunity.mcp.security.server.apikey.web.ApiKeyAuthenticationFilter;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -46,12 +48,18 @@ public class McpApiKeyConfigurer extends AbstractHttpConfigurer<McpApiKeyConfigu
 
 	private @Nullable AuthenticationConverter authenticationConverter;
 
+	private boolean unauthorizedOnMissingApiKey = true;
+
 	public @Nullable SessionBindingConfigurer sessionBindingConfigurer;
 
 	@Override
 	public void init(HttpSecurity http) {
 		Assert.notNull(this.apiKeyEntityRepository, "apiKeyRepository cannot be null");
 		http.authenticationProvider(postProcess(new ApiKeyAuthenticationProvider<>(this.apiKeyEntityRepository)));
+		if (this.unauthorizedOnMissingApiKey && http.getConfigurer(McpServerOAuth2Configurer.class) == null) {
+			http.exceptionHandling((exceptions) -> exceptions
+				.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
+		}
 		registerCsrfOverride(http);
 		if (this.sessionBindingConfigurer != null) {
 			this.sessionBindingConfigurer.init(http);
@@ -119,6 +127,18 @@ public class McpApiKeyConfigurer extends AbstractHttpConfigurer<McpApiKeyConfigu
 	 */
 	public McpApiKeyConfigurer authenticationConverter(AuthenticationConverter authenticationConverter) {
 		this.authenticationConverter = authenticationConverter;
+		return this;
+	}
+
+	/**
+	 * Configure whether requests without an API key should receive an HTTP 401 response
+	 * when no other authentication mechanism authenticates the request. Defaults to
+	 * {@code true}.
+	 * @param unauthorizedOnMissingApiKey whether to configure the HTTP 401 entry point
+	 * @return The {@link McpApiKeyConfigurer} for further configuration
+	 */
+	public McpApiKeyConfigurer unauthorizedOnMissingApiKey(boolean unauthorizedOnMissingApiKey) {
+		this.unauthorizedOnMissingApiKey = unauthorizedOnMissingApiKey;
 		return this;
 	}
 

--- a/mcp-server-security/src/test/java/org/springaicommunity/mcp/security/server/config/McpApiKeyConfigurerTest.java
+++ b/mcp-server-security/src/test/java/org/springaicommunity/mcp/security/server/config/McpApiKeyConfigurerTest.java
@@ -21,14 +21,17 @@ import org.springaicommunity.mcp.security.server.apikey.web.ApiKeyAuthentication
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -39,7 +42,9 @@ import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.RouterFunctions;
 import org.springframework.web.servlet.function.ServerResponse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.springaicommunity.mcp.security.server.config.McpApiKeyConfigurer.mcpServerApiKey;
+import static org.springaicommunity.mcp.security.server.config.McpServerOAuth2Configurer.mcpServerOAuth2;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
@@ -77,10 +82,10 @@ class McpApiKeyConfigurerTest {
 	}
 
 	@Test
-	void noApiKeyForbidden() {
+	void noApiKeyUnauthorized() {
 		var resp = this.mvc.get().uri("/default");
 
-		assertThat(resp).hasStatus(HttpStatus.FORBIDDEN);
+		assertThat(resp).hasStatus(HttpStatus.UNAUTHORIZED);
 	}
 
 	@Test
@@ -126,6 +131,18 @@ class McpApiKeyConfigurerTest {
 		var resp = this.mvc.get().uri("/converter").queryParam("apiKey", "invalid.invalid");
 
 		assertThat(resp).hasStatus(HttpStatus.UNAUTHORIZED);
+	}
+
+	@Test
+	void noCredentialsWithOAuth2AlsoConfiguredThenWwwAuthenticate() {
+		assertThat(this.mvc.get().uri("/combined")).hasStatus(HttpStatus.UNAUTHORIZED)
+			.headers()
+			.containsHeader(HttpHeaders.WWW_AUTHENTICATE);
+	}
+
+	@Test
+	void unauthorizedOnMissingApiKeyDisabledThenPreservesCustomAuthenticationEntryPoint() {
+		assertThat(this.mvc.get().uri("/custom-entry-point")).hasStatus(HttpStatus.I_AM_A_TEAPOT);
 	}
 
 	@Test
@@ -198,6 +215,27 @@ class McpApiKeyConfigurerTest {
 					}
 					return ApiKeyAuthenticationToken.unauthenticated(ApiKeyImpl.from(extractedKey));
 				}))
+				.build();
+		}
+
+		@Bean
+		SecurityFilterChain combinedApiKeyAndOAuth2SecurityFilterChain(HttpSecurity http) throws Exception {
+			return http.securityMatcher("/combined/**")
+				.authorizeHttpRequests(authz -> authz.anyRequest().authenticated())
+				.with(mcpServerApiKey(), apiKey -> apiKey.apiKeyRepository(repo()))
+				.with(mcpServerOAuth2(),
+						oauth2 -> oauth2.authorizationServer("https://test-issuer.example.com")
+							.jwtDecoder(mock(JwtDecoder.class)))
+				.build();
+		}
+
+		@Bean
+		SecurityFilterChain customAuthenticationEntryPointSecurityFilterChain(HttpSecurity http) throws Exception {
+			return http.securityMatcher("/custom-entry-point/**")
+				.authorizeHttpRequests(authz -> authz.anyRequest().authenticated())
+				.exceptionHandling(exceptions -> exceptions
+					.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.I_AM_A_TEAPOT)))
+				.with(mcpServerApiKey(), apiKey -> apiKey.apiKeyRepository(repo()).unauthorizedOnMissingApiKey(false))
 				.build();
 		}
 


### PR DESCRIPTION
Closes #46.

## Problem

When an API-key-protected MCP endpoint receives a request without an API key, the API key authentication filter passes the request through so another configured authentication mechanism can authenticate it.

If no mechanism authenticates the request, Spring Security currently uses its default entry point and returns `403 Forbidden`. Since the request is unauthenticated, it should instead return `401 Unauthorized`.

An unconditional API key entry point is not sufficient because it overrides the OAuth2 resource server entry point when API key and OAuth2 authentication are configured together. This prevents the OAuth2 `WWW-Authenticate` challenge from being returned.

## Changes

- Configure a `401 Unauthorized` entry point for API-key authentication when MCP OAuth2 security is not configured.
- Preserve the OAuth2 entry point when API key and OAuth2 authentication are used together.
- Update the missing API key test to expect `401 Unauthorized`.
- Add regression coverage verifying that combined API key and OAuth2 configuration still returns a `WWW-Authenticate` header.
- Document the response behavior for missing and invalid API keys.

## Result

- API-key-only server with no credentials: `401 Unauthorized`
- API key + OAuth2 server with no credentials: `401 Unauthorized` with the OAuth2 `WWW-Authenticate` challenge
- Invalid API key: `401 Unauthorized`
- Successful alternative authentication: request proceeds normally
- Authenticated requests without sufficient authorization: existing `403 Forbidden` behavior is unchanged

## Testing

```
./mvnw -pl mcp-server-security \
  -Dtest=McpApiKeyConfigurerTest,ApiKeyAuthenticationFilterTests \
  clean test