### PR TITLE
README: use McpClientCustomizer in the client customizer snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,7 +675,7 @@ When not using the Boot auto-configuration, you need to add an `AuthenticationMc
 class McpConfiguration {
 
     @Bean
-    McpSyncClientCustomizer syncClientCustomizer() {
+    McpClientCustomizer<McpClient.SyncSpec> syncClientCustomizer() {
         return (name, syncSpec) ->
                 syncSpec.transportContextProvider(
                         new AuthenticationMcpTransportContextProvider()
@@ -719,7 +719,7 @@ When not using the Boot auto-configuration, you need to add an `AuthenticationMc
 class McpConfiguration {
 
     @Bean
-    McpSyncClientCustomizer syncClientCustomizer() {
+    McpClientCustomizer<McpClient.SyncSpec> syncClientCustomizer() {
         return (name, syncSpec) ->
                 syncSpec.transportContextProvider(
                         new AuthenticationMcpTransportContextProvider()
@@ -821,7 +821,7 @@ for example, with a Sync client (async works similarly):
 class McpConfiguration {
 
     @Bean
-    McpSyncClientCustomizer syncClientCustomizer() {
+    McpClientCustomizer<McpClient.SyncSpec> syncClientCustomizer() {
         return (name, syncSpec) -> syncSpec.transportContextProvider(() -> {
             var myThing = MyThreadLocalThing.get();
             return McpTransportContext.create(Map.of("custom-key", myThing));
@@ -846,7 +846,7 @@ For WebClient-based filter functions, the `McpTransportContext` will be availabl
 class McpConfiguration {
 
     @Bean
-    McpSyncClientCustomizer syncClientCustomizer() {
+    McpClientCustomizer<McpClient.SyncSpec> syncClientCustomizer() {
         return (name, syncSpec) -> syncSpec.transportContextProvider(() -> {
             var myThing = MyThreadLocalThing.get();
             return McpTransportContext.create(Map.of("custom-key", myThing));

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/AuthenticationMcpTransportContextProvider.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/AuthenticationMcpTransportContextProvider.java
@@ -51,12 +51,11 @@ import org.springframework.web.reactive.function.client.WebClient;
  * {@link McpAsyncHttpClientRequestCustomizer} for {@link HttpClient}-based transports,
  * and with {@link ExchangeFilterFunction} for {@link WebClient}-based transports.
  * <p>
- * This is usually used through a Spring AI {@code McpSyncClientCustomizer} or
- * {@code McpAsyncClientCustomizer}, like so:
+ * This is usually used through a Spring AI {@code McpClientCustomizer}, like so:
  *
  * <pre>
  * &#x40;Bean
- * McpSyncClientCustomizer syncClientCustomizer() {
+ * McpClientCustomizer&lt;McpClient.SyncSpec&gt; syncClientCustomizer() {
  *   return (name, syncSpec) -> syncSpec
  *     .transportContextProvider(
  *       new AuthenticationMcpTransportContextProvider()


### PR DESCRIPTION
The `@Bean` snippets in the README and in `AuthenticationMcpTransportContextProvider`'s javadoc declare the bean as `McpSyncClientCustomizer`. Spring AI removed that type in 2.0.0-M3, replacing the sync and async client customizers with the parameterized `McpClientCustomizer<B>`. This project moved to M3 in d477aa3, which migrated the Java sources but not the documentation, and now targets 2.0.0 — so the snippets no longer compile against the version it ships with.

Configurations of this bean in the repository already use the current type — for example `samples/sample-mcp-client-webclient/.../McpConfiguration.java`, `samples/integration-tests/src/main/.../McpClientConfiguration.java` and `mcp-client-security-spring-boot/.../McpOAuth2ClientConfigurations.java`:

```java
@Bean
McpClientCustomizer<McpClient.SyncSpec> syncClientCustomizer() {
    return (name, syncSpec) -> syncSpec.transportContextProvider(new AuthenticationMcpTransportContextProvider());
}
```

The lambda is unchanged — `McpClientCustomizer` takes the same `(name, spec)` arguments — so this is the type only. Four snippets in the README and the one in the javadoc are updated, along with the sentence naming `McpSyncClientCustomizer` and `McpAsyncClientCustomizer`, which now names `McpClientCustomizer` for both. In the javadoc the angle brackets are written as HTML entities, as the surrounding `<pre>` block already does for the annotation.