### PR TITLE
Authorization Server: customize authorization code request validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1129,6 +1129,28 @@ ClientIdMetadataDocumentRegisteredClientRepository cimdClientRepository() {
 }
 ```
 
+The authorization server validates the redirect URI in an authorization request against
+the redirect URIs from the client metadata document. Some clients, such as Claude Code, use a dynamic port with
+the `localhost` host. To support those clients, configure `LocalhostWildcardPortValidator`
+alongside Spring Authorization Server's default scope validator:
+
+```java
+@Bean
+SecurityFilterChain securityFilterChain(
+        HttpSecurity http) {
+    return http
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .with(McpAuthorizationServerConfigurer.mcpAuthorizationServer(), mcp -> {
+                mcp.cimd(true);
+                mcp.authorizationCodeRequestValidator(
+                        new LocalhostWildcardPortValidator()
+                                .andThen(DEFAULT_SCOPE_VALIDATOR));
+            })
+            .formLogin(withDefaults())
+            .build();
+}
+```
+
 ### Known limitations
 
 - Spring WebFlux servers are not supported.

--- a/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/LocalhostWildcardPortValidator.java
+++ b/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/LocalhostWildcardPortValidator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.authorizationserver.config;
+
+import java.util.function.Consumer;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationContext;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationToken;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import static org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR;
+
+/**
+ * Validates authorization code request redirect URIs, allowing the port to vary when both
+ * the requested and registered redirect URI use the {@code localhost} host.
+ * <p>
+ * <strong>WARNING:</strong> OAuth 2.1 does not recommend using {@code localhost} for
+ * loopback redirection. Some clients use it, however, and require this compatibility
+ * behavior. Requests that do not qualify for localhost wildcard port matching are
+ * delegated to Spring Authorization Server's default redirect URI validator.
+ *
+ * @author Arnab Nandy
+ * @see <a href=
+ * "https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-15.html#section-8.4.2">OAuth
+ * 2.1, Loopback Interface Redirection</a>
+ */
+public final class LocalhostWildcardPortValidator
+		implements Consumer<OAuth2AuthorizationCodeRequestAuthenticationContext> {
+
+	private static final String LOCALHOST = "localhost";
+
+	@Override
+	public void accept(OAuth2AuthorizationCodeRequestAuthenticationContext context) {
+		OAuth2AuthorizationCodeRequestAuthenticationToken authentication = context.getAuthentication();
+		@Nullable String requestedRedirectUri = authentication.getRedirectUri();
+		@Nullable UriComponents requested = parseLocalhostRedirectUri(requestedRedirectUri);
+		if (requested != null && context.getRegisteredClient()
+			.getRedirectUris()
+			.stream()
+			.anyMatch(registeredRedirectUri -> matchesExceptPort(requested, registeredRedirectUri))) {
+			return;
+		}
+		DEFAULT_REDIRECT_URI_VALIDATOR.accept(context);
+	}
+
+	@Nullable private static UriComponents parseLocalhostRedirectUri(@Nullable String redirectUri) {
+		if (redirectUri == null) {
+			return null;
+		}
+		try {
+			UriComponents uri = UriComponentsBuilder.fromUriString(redirectUri).build();
+			return LOCALHOST.equalsIgnoreCase(uri.getHost()) ? uri : null;
+		}
+		catch (IllegalArgumentException ex) {
+			return null;
+		}
+	}
+
+	private static boolean matchesExceptPort(UriComponents requested, String registeredRedirectUri) {
+		try {
+			UriComponentsBuilder registered = UriComponentsBuilder.fromUriString(registeredRedirectUri);
+			registered.port(requested.getPort());
+			return registered.build().toString().equals(requested.toString());
+		}
+		catch (IllegalArgumentException ex) {
+			return false;
+		}
+	}
+
+}

--- a/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationCodeRequestValidatorPostProcessor.java
+++ b/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationCodeRequestValidatorPostProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.authorizationserver.config;
+
+import java.util.function.Consumer;
+
+import org.springframework.security.config.ObjectPostProcessor;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationContext;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationProvider;
+
+/**
+ * Post-processor to set the authorization code request validator on
+ * {@link OAuth2AuthorizationCodeRequestAuthenticationProvider}.
+ * <p>
+ * For internal use only.
+ *
+ * @author Arnab Nandy
+ */
+class McpAuthorizationCodeRequestValidatorPostProcessor
+		implements ObjectPostProcessor<OAuth2AuthorizationCodeRequestAuthenticationProvider> {
+
+	private final Consumer<OAuth2AuthorizationCodeRequestAuthenticationContext> validator;
+
+	McpAuthorizationCodeRequestValidatorPostProcessor(
+			Consumer<OAuth2AuthorizationCodeRequestAuthenticationContext> validator) {
+		this.validator = validator;
+	}
+
+	@Override
+	public OAuth2AuthorizationCodeRequestAuthenticationProvider postProcess(
+			OAuth2AuthorizationCodeRequestAuthenticationProvider object) {
+		object.setAuthenticationValidator(this.validator);
+		return object;
+	}
+
+}

--- a/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationServerConfigurer.java
+++ b/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationServerConfigurer.java
@@ -38,6 +38,8 @@ import org.springframework.security.config.annotation.web.configurers.oauth2.ser
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OAuth2AuthorizationServerConfigurer;
 import org.springframework.security.oauth2.core.OAuth2Token;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationContext;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationValidator;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientRegistrationAuthenticationContext;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientRegistrationAuthenticationValidator;
 import org.springframework.security.oauth2.server.authorization.mcp.token.ResourceIdentifierAudienceTokenCustomizer;
@@ -69,6 +71,8 @@ public class McpAuthorizationServerConfigurer
 	private boolean supportClientIdMetadataDocument = false;
 
 	private Consumer<OAuth2ClientRegistrationAuthenticationContext> clientRegistrationValidator = new OAuth2ClientRegistrationAuthenticationValidator();
+
+	private Consumer<OAuth2AuthorizationCodeRequestAuthenticationContext> authorizationCodeRequestValidator = new OAuth2AuthorizationCodeRequestAuthenticationValidator();
 
 	public static McpAuthorizationServerConfigurer mcpAuthorizationServer() {
 		return new McpAuthorizationServerConfigurer();
@@ -122,6 +126,19 @@ public class McpAuthorizationServerConfigurer
 		return this;
 	}
 
+	/**
+	 * Update the validator for incoming authorization code requests.
+	 * @param authorizationCodeRequestValidator the validator. Defaults to
+	 * {@link OAuth2AuthorizationCodeRequestAuthenticationValidator};
+	 * @return The {@link McpAuthorizationServerConfigurer} for further configuration.
+	 */
+	public McpAuthorizationServerConfigurer authorizationCodeRequestValidator(
+			Consumer<OAuth2AuthorizationCodeRequestAuthenticationContext> authorizationCodeRequestValidator) {
+		Assert.notNull(authorizationCodeRequestValidator, "authorizationCodeRequestValidator cannot be null");
+		this.authorizationCodeRequestValidator = authorizationCodeRequestValidator;
+		return this;
+	}
+
 	@Override
 	public void init(HttpSecurity http) {
 		http.authorizeHttpRequests(authz -> {
@@ -130,6 +147,8 @@ public class McpAuthorizationServerConfigurer
 			}
 		}).oauth2AuthorizationServer(authServer -> {
 			authServer.addObjectPostProcessor(McpNoScopeClientConsentNotRequired.postProcessor());
+			authServer.addObjectPostProcessor(
+					new McpAuthorizationCodeRequestValidatorPostProcessor(this.authorizationCodeRequestValidator));
 			authServer.addObjectPostProcessor(
 					new McpClientRegistrationValidatorPostProcessor(this.clientRegistrationValidator));
 			authServer.authorizationServerMetadataEndpoint(metadataEndpoint -> {

--- a/mcp-authorization-server/src/test/java/org/springaicommunity/mcp/security/authorizationserver/config/LocalhostWildcardPortValidatorTests.java
+++ b/mcp-authorization-server/src/test/java/org/springaicommunity/mcp/security/authorizationserver/config/LocalhostWildcardPortValidatorTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.authorizationserver.config;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationContext;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationException;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationToken;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+
+class LocalhostWildcardPortValidatorTests {
+
+	private final LocalhostWildcardPortValidator validator = new LocalhostWildcardPortValidator();
+
+	@Test
+	void allowsDifferentPortForLocalhost() {
+		var context = context("http://localhost:54321/callback", "http://localhost:8080/callback");
+
+		assertThatNoException().isThrownBy(() -> this.validator.accept(context));
+	}
+
+	@Test
+	void allowsImplicitDefaultPortForLocalhost() {
+		var context = context("http://localhost/callback", "http://localhost:8080/callback");
+
+		assertThatNoException().isThrownBy(() -> this.validator.accept(context));
+	}
+
+	@Test
+	void rejectsDifferentPathForLocalhost() {
+		var context = context("http://localhost:54321/other-callback", "http://localhost:8080/callback");
+
+		assertThatExceptionOfType(OAuth2AuthorizationCodeRequestAuthenticationException.class)
+			.isThrownBy(() -> this.validator.accept(context));
+	}
+
+	@Test
+	void delegatesNonLocalhostRedirectUriToDefaultValidator() {
+		var context = context("https://example.com/callback", "https://registered.example.com/callback");
+
+		assertThatExceptionOfType(OAuth2AuthorizationCodeRequestAuthenticationException.class)
+			.isThrownBy(() -> this.validator.accept(context));
+	}
+
+	private static OAuth2AuthorizationCodeRequestAuthenticationContext context(String requestedRedirectUri,
+			String registeredRedirectUri) {
+		Authentication principal = mock(Authentication.class);
+		var authentication = new OAuth2AuthorizationCodeRequestAuthenticationToken("https://authorization-server.test",
+				"client-id", principal, requestedRedirectUri, "state", Set.of(), Map.of());
+		var registeredClient = RegisteredClient.withId("client-id")
+			.clientId("client-id")
+			.clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.redirectUri(registeredRedirectUri)
+			.build();
+		return OAuth2AuthorizationCodeRequestAuthenticationContext.with(authentication)
+			.registeredClient(registeredClient)
+			.build();
+	}
+
+}

--- a/mcp-authorization-server/src/test/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationServerConfigurerTest.java
+++ b/mcp-authorization-server/src/test/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationServerConfigurerTest.java
@@ -60,6 +60,7 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springaicommunity.mcp.security.authorizationserver.config.McpAuthorizationServerConfigurer.mcpAuthorizationServer;
+import static org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationValidator.DEFAULT_SCOPE_VALIDATOR;
 import static org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientRegistrationAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR;
 
 @ExtendWith(SpringExtension.class)
@@ -224,6 +225,8 @@ class McpAuthorizationServerConfigurerTest {
 					mcpAuthzServer.authorizationServer(authzServer -> authzServerCustomizationCount.incrementAndGet());
 					mcpAuthzServer.cimd(true);
 					mcpAuthzServer.dynamicClientRegistrationValidator(clientRegistrationValidator);
+					mcpAuthzServer.authorizationCodeRequestValidator(
+							new LocalhostWildcardPortValidator().andThen(DEFAULT_SCOPE_VALIDATOR));
 				});
 			return http.build();
 		}


### PR DESCRIPTION
## Summary

- Add an authorization code request validator hook to `McpAuthorizationServerConfigurer`
- Apply custom validators using the existing object post-processor pattern
- Allow applications to support CIMD clients that use dynamic `localhost` redirect URI ports
- Preserve Spring Authorization Server’s strict validator as the default
- Document configuration and security considerations
- Add test coverage for custom redirect URI validation

Fixes #84

## Testing

```
./mvnw -pl mcp-authorization-server -Dtest=McpAuthorizationServerConfigurerTest test
```