### PR TITLE
Add offline access support for MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,8 @@ spring.ai.mcp.client.streamable-http.connections.my-mcp-server.url=http://localh
 
 # Enable Dynamic Client Registration (default: false)
 spring.ai.mcp.client.authorization.dynamic-client-registration.enabled=true
+# Request refresh tokens with offline_access when supported by the authorization server (default: false)
+spring.ai.mcp.client.authorization.dynamic-client-registration.request-offline-access=true
 # For development purposes, allow loopback addresses for MCP Servers and Auth Servers (default: false)
 spring.ai.mcp.client.authorization.dynamic-client-registration.allow-loopback-addresses=true
 ```
@@ -610,6 +612,10 @@ When enabled, the flow works as follows:
 
 DCR is disabled by default in the `mcp-client-security-spring-boot` auto-configuration.
 To enable it, set `spring.ai.mcp.client.authorization.dynamic-client-registration.enabled=true`.
+Clients that can securely store refresh tokens can opt in to requesting them with
+`spring.ai.mcp.client.authorization.dynamic-client-registration.request-offline-access=true`. In accordance with
+[SEP-2207](https://modelcontextprotocol.io/seps/2207-oidc-refresh-token-guidance), this adds `refresh_token` to the
+registered grant types and requests `offline_access` only when the authorization server advertises that scope.
 When disabled, ensure you either have a single `ClientRegistration` registered under
 `spring.security.oauth2.client.registration`, or provide your own `OAuth2HttpClientTransportCustomizer` bean.
 Scope step-up is still supported when DCR is disabled.

--- a/mcp-client-security-spring-boot/src/main/java/org/springaicommunity/mcp/security/client/boot/McpOAuth2ClientConfigurations.java
+++ b/mcp-client-security-spring-boot/src/main/java/org/springaicommunity/mcp/security/client/boot/McpOAuth2ClientConfigurations.java
@@ -109,9 +109,11 @@ class McpOAuth2ClientConfigurations {
 		DefaultMcpOAuth2DcrClientManager mcpOAuth2ClientManager(
 				McpClientRegistrationRepository mcpClientRegistrationRepository,
 				DynamicClientRegistrationService dynamicClientRegistrationService,
-				McpMetadataDiscoveryService mcpMetadataDiscoveryService, UrlValidator urlValidator) {
+				McpMetadataDiscoveryService mcpMetadataDiscoveryService, UrlValidator urlValidator,
+				McpOAuth2ClientProperties properties) {
 			return new DefaultMcpOAuth2DcrClientManager(mcpClientRegistrationRepository,
-					dynamicClientRegistrationService, mcpMetadataDiscoveryService, urlValidator);
+					dynamicClientRegistrationService, mcpMetadataDiscoveryService, urlValidator,
+					properties.getDynamicClientRegistration().isRequestOfflineAccess());
 		}
 
 		@Bean

--- a/mcp-client-security-spring-boot/src/main/java/org/springaicommunity/mcp/security/client/boot/McpOAuth2ClientProperties.java
+++ b/mcp-client-security-spring-boot/src/main/java/org/springaicommunity/mcp/security/client/boot/McpOAuth2ClientProperties.java
@@ -60,6 +60,13 @@ public class McpOAuth2ClientProperties {
 		 */
 		private boolean allowLoopbackAddresses = false;
 
+		/**
+		 * Request the {@code offline_access} scope for authorization code clients when
+		 * the authorization server advertises support for it. This also advertises the
+		 * {@code refresh_token} grant type during dynamic client registration.
+		 */
+		private boolean requestOfflineAccess = false;
+
 		public boolean isAllowLoopbackAddresses() {
 			return allowLoopbackAddresses;
 		}
@@ -74,6 +81,14 @@ public class McpOAuth2ClientProperties {
 
 		public void setEnabled(boolean enabled) {
 			this.enabled = enabled;
+		}
+
+		public boolean isRequestOfflineAccess() {
+			return requestOfflineAccess;
+		}
+
+		public void setRequestOfflineAccess(boolean requestOfflineAccess) {
+			this.requestOfflineAccess = requestOfflineAccess;
 		}
 
 	}

--- a/mcp-client-security-spring-boot/src/test/java/org/springaicommunity/mcp/security/client/boot/McpOAuth2ClientAutoConfigurationTests.java
+++ b/mcp-client-security-spring-boot/src/test/java/org/springaicommunity/mcp/security/client/boot/McpOAuth2ClientAutoConfigurationTests.java
@@ -109,6 +109,16 @@ class McpOAuth2ClientAutoConfigurationTests {
 	}
 
 	@Test
+	void requestOfflineAccessProperty() {
+		this.contextRunner
+			.withPropertyValues(
+					"spring.ai.mcp.client.authorization.dynamic-client-registration.request-offline-access=true")
+			.run(context -> assertThat(context.getBean(McpOAuth2ClientProperties.class)
+				.getDynamicClientRegistration()
+				.isRequestOfflineAccess()).isTrue());
+	}
+
+	@Test
 	void clientRegistrationRepositoryLoadsOAuth2ClientProperties() {
 		this.contextRunner
 			.withPropertyValues("spring.security.oauth2.client.registration.test.client-id=test-client-id",

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DefaultMcpOAuth2DcrClientManager.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DefaultMcpOAuth2DcrClientManager.java
@@ -16,6 +16,9 @@
 
 package org.springaicommunity.mcp.security.client.sync.oauth2.registration;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
@@ -29,7 +32,6 @@ import org.springaicommunity.mcp.security.common.url.InvalidUrlException;
 import org.springaicommunity.mcp.security.common.url.UrlValidator;
 
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrations;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.util.Assert;
@@ -61,6 +63,8 @@ public class DefaultMcpOAuth2DcrClientManager implements McpOAuth2DcrClientManag
 
 	private final ScopeStepUp scopeStepUp;
 
+	private final boolean requestOfflineAccess;
+
 	/**
 	 * @deprecated use {@link DefaultMcpOAuth2DcrClientManager
 	 * (McpClientRegistrationRepository, DynamicClientRegistrationService,
@@ -75,6 +79,12 @@ public class DefaultMcpOAuth2DcrClientManager implements McpOAuth2DcrClientManag
 	public DefaultMcpOAuth2DcrClientManager(McpClientRegistrationRepository repository,
 			DynamicClientRegistrationService clientRegistrationService, McpMetadataDiscoveryService discovery,
 			UrlValidator urlValidator) {
+		this(repository, clientRegistrationService, discovery, urlValidator, false);
+	}
+
+	public DefaultMcpOAuth2DcrClientManager(McpClientRegistrationRepository repository,
+			DynamicClientRegistrationService clientRegistrationService, McpMetadataDiscoveryService discovery,
+			UrlValidator urlValidator, boolean requestOfflineAccess) {
 		Assert.notNull(repository, "repository cannot be null");
 		Assert.notNull(clientRegistrationService, "clientRegistrationService cannot be null");
 		Assert.notNull(discovery, "discovery cannot be null");
@@ -84,6 +94,7 @@ public class DefaultMcpOAuth2DcrClientManager implements McpOAuth2DcrClientManag
 		this.urlValidator = urlValidator;
 		this.repository = repository;
 		this.scopeStepUp = new ScopeStepUp(repository);
+		this.requestOfflineAccess = requestOfflineAccess;
 	}
 
 	@Override
@@ -131,42 +142,65 @@ public class DefaultMcpOAuth2DcrClientManager implements McpOAuth2DcrClientManag
 				"cannot find authorization_servers from MCP Server's protected resource metadata");
 		var issuerUrl = mcpMetadata.protectedResourceMetadata().authorizationServers().get(0);
 		log.debug("Discovered authorization server [{}] for registration [{}]", issuerUrl, registrationId);
-		var finalRegistrationRequest = updateScopes(registrationRequest, mcpMetadata);
+		var authorizationServerMetadata = this.clientRegistrationService.getAuthorizationServerMetadata(issuerUrl);
+		var finalRegistrationRequest = updateRegistrationRequest(registrationRequest, mcpMetadata,
+				authorizationServerMetadata);
 		log.debug("Performing dynamic client registration at [{}] for registration [{}]", issuerUrl, registrationId);
-		var registrationResponse = this.clientRegistrationService.register(finalRegistrationRequest, issuerUrl);
+		var registrationResponse = this.clientRegistrationService.register(finalRegistrationRequest,
+				authorizationServerMetadata);
 		log.debug("Dynamic client registration successful for registration [{}], clientId=[{}]", registrationId,
 				registrationResponse.clientId());
-		var clientRegistration = toClientRegistration(registrationId, issuerUrl, finalRegistrationRequest,
-				registrationResponse);
+		var clientRegistration = toClientRegistration(registrationId, authorizationServerMetadata,
+				finalRegistrationRequest, registrationResponse);
 		validateClientRegistration(clientRegistration);
 		this.repository.addClientRegistration(clientRegistration, mcpMetadata.protectedResourceMetadata().resource());
 	}
 
-	private DynamicClientRegistrationRequest updateScopes(DynamicClientRegistrationRequest originalRequest,
-			McpMetadata mcpMetadata) {
-		if (StringUtils.hasText(originalRequest.getScope())) {
-			return originalRequest;
-		}
-
-		if (mcpMetadata.wwwAuthenticateParameters() != null
+	private DynamicClientRegistrationRequest updateRegistrationRequest(DynamicClientRegistrationRequest originalRequest,
+			McpMetadata mcpMetadata, ClientRegistration authorizationServerMetadata) {
+		var builder = DynamicClientRegistrationRequest.from(originalRequest);
+		if (!StringUtils.hasText(originalRequest.getScope()) && mcpMetadata.wwwAuthenticateParameters() != null
 				&& StringUtils.hasText(mcpMetadata.wwwAuthenticateParameters().getScope())) {
-			return DynamicClientRegistrationRequest.from(originalRequest)
-				.scope(mcpMetadata.wwwAuthenticateParameters().getScope())
-				.build();
+			builder.scope(mcpMetadata.wwwAuthenticateParameters().getScope());
 		}
-		else if (!CollectionUtils.isEmpty(mcpMetadata.protectedResourceMetadata().scopesSupported())) {
-			return DynamicClientRegistrationRequest.from(originalRequest)
-				.scope(mcpMetadata.protectedResourceMetadata().scopesSupported())
-				.build();
+		else if (!StringUtils.hasText(originalRequest.getScope())
+				&& !CollectionUtils.isEmpty(mcpMetadata.protectedResourceMetadata().scopesSupported())) {
+			builder.scope(mcpMetadata.protectedResourceMetadata().scopesSupported());
 		}
 
-		return originalRequest;
+		if (this.requestOfflineAccess
+				&& originalRequest.getGrantTypes().contains(AuthorizationGrantType.AUTHORIZATION_CODE.getValue())
+				&& supportsOfflineAccess(authorizationServerMetadata)) {
+			var grantTypes = new ArrayList<>(
+					originalRequest.getGrantTypes().stream().map(AuthorizationGrantType::new).toList());
+			if (!originalRequest.getGrantTypes().contains(AuthorizationGrantType.REFRESH_TOKEN.getValue())) {
+				grantTypes.add(AuthorizationGrantType.REFRESH_TOKEN);
+			}
+			builder.grantTypes(grantTypes);
+			var scopes = new LinkedHashSet<String>();
+			var scope = builder.scope;
+			if (StringUtils.hasText(scope)) {
+				scopes.addAll(List.of(scope.split(" ")));
+			}
+			scopes.add("offline_access");
+			builder.scope(scopes.stream().toList());
+		}
+
+		return builder.build();
 	}
 
-	private static ClientRegistration toClientRegistration(String registrationId, String issuerUrl,
-			DynamicClientRegistrationRequest registrationRequest,
+	private boolean supportsOfflineAccess(ClientRegistration authorizationServerMetadata) {
+		var scopesSupported = authorizationServerMetadata.getProviderDetails()
+			.getConfigurationMetadata()
+			.get("scopes_supported");
+		return scopesSupported instanceof Collection<?> scopes && scopes.contains("offline_access");
+	}
+
+	private static ClientRegistration toClientRegistration(String registrationId,
+			ClientRegistration authorizationServerMetadata, DynamicClientRegistrationRequest registrationRequest,
 			DynamicClientRegistrationResponse registrationResponse) {
-		ClientRegistration.Builder registrationBuilder = ClientRegistrations.fromIssuerLocation(issuerUrl)
+		ClientRegistration.Builder registrationBuilder = ClientRegistration
+			.withClientRegistration(authorizationServerMetadata)
 			.registrationId(registrationId);
 		registrationBuilder.clientId(registrationResponse.clientId());
 

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DynamicClientRegistrationRequest.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DynamicClientRegistrationRequest.java
@@ -115,6 +115,9 @@ public class DynamicClientRegistrationRequest {
 		builder.clientName = other.clientName;
 		builder.clientUri = other.clientUri;
 		builder.scope = other.scope;
+		if (other.applicationType != null) {
+			builder.applicationType(other.applicationType);
+		}
 		return builder;
 	}
 

--- a/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DynamicClientRegistrationService.java
+++ b/mcp-client-security/src/main/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DynamicClientRegistrationService.java
@@ -30,6 +30,7 @@ import org.springaicommunity.mcp.security.common.url.UrlValidator;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrations;
 import org.springframework.security.oauth2.core.converter.ClaimConversionService;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
@@ -71,18 +72,31 @@ public class DynamicClientRegistrationService {
 
 	public DynamicClientRegistrationResponse register(DynamicClientRegistrationRequest registrationRequest,
 			String authServerUrl) {
-		var registrationEndpoint = findRegistrationEndpoint(authServerUrl);
+		return register(registrationRequest, getAuthorizationServerMetadata(authServerUrl));
+	}
+
+	DynamicClientRegistrationResponse register(DynamicClientRegistrationRequest registrationRequest,
+			ClientRegistration authorizationServerMetadata) {
+		var authServerUrl = authorizationServerMetadata.getProviderDetails().getIssuerUri();
+		var registrationEndpoint = authorizationServerMetadata.getProviderDetails()
+			.getConfigurationMetadata()
+			.get("registration_endpoint");
+		if (registrationEndpoint == null) {
+			throw new IllegalStateException(
+					"No registration endpoint found for auth server [%s]".formatted(authServerUrl));
+		}
+		var registrationEndpointUrl = registrationEndpoint.toString();
 		try {
-			urlValidator.validateUrl(registrationEndpoint);
+			urlValidator.validateUrl(registrationEndpointUrl);
 		}
 		catch (InvalidUrlException e) {
 			throw new IllegalStateException("Invalid registration_endpoint URL: " + e.getMessage(), e);
 		}
-		log.debug("Performing dynamic client registration at [{}]", registrationEndpoint);
+		log.debug("Performing dynamic client registration at [{}]", registrationEndpointUrl);
 		var typeRef = new ParameterizedTypeReference<Map<String, Object>>() {
 		};
 		var response = restClient.post()
-			.uri(registrationEndpoint)
+			.uri(registrationEndpointUrl)
 			.contentType(MediaType.APPLICATION_JSON)
 			.body(createRegistrationRequest(registrationRequest))
 			.retrieve()
@@ -150,22 +164,15 @@ public class DynamicClientRegistrationService {
 		return parameters;
 	}
 
-	private String findRegistrationEndpoint(String authServerUrl) {
+	ClientRegistration getAuthorizationServerMetadata(String authServerUrl) {
 		try {
 			urlValidator.validateUrl(authServerUrl);
 		}
 		catch (InvalidUrlException e) {
 			throw new IllegalStateException("Invalid authorization server URL: " + e.getMessage(), e);
 		}
-		log.debug("Discovering registration endpoint for auth server [{}]", authServerUrl);
-		var builder = ClientRegistrations.fromIssuerLocation(authServerUrl).clientId("~~~~ignored~~~~").build();
-		var registrationEndpoint = builder.getProviderDetails().getConfigurationMetadata().get("registration_endpoint");
-		if (registrationEndpoint == null) {
-			throw new IllegalStateException(
-					"No registration endpoint found for auth server [%s]".formatted(authServerUrl));
-		}
-		log.debug("Found registration endpoint [{}]", registrationEndpoint);
-		return registrationEndpoint.toString();
+		log.debug("Discovering metadata for auth server [{}]", authServerUrl);
+		return ClientRegistrations.fromIssuerLocation(authServerUrl).clientId("~~~~ignored~~~~").build();
 	}
 
 }

--- a/mcp-client-security/src/test/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DefaultMcpOAuth2DcrClientManagerTests.java
+++ b/mcp-client-security/src/test/java/org/springaicommunity/mcp/security/client/sync/oauth2/registration/DefaultMcpOAuth2DcrClientManagerTests.java
@@ -20,13 +20,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
+import org.mockito.ArgumentCaptor;
 import org.springaicommunity.mcp.security.client.sync.oauth2.metadata.McpMetadata;
 import org.springaicommunity.mcp.security.client.sync.oauth2.metadata.McpMetadataDiscoveryService;
 import org.springaicommunity.mcp.security.client.sync.oauth2.metadata.ProtectedResourceMetadata;
@@ -37,7 +35,6 @@ import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrations;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +43,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -73,8 +69,6 @@ class DefaultMcpOAuth2DcrClientManagerTests {
 
 	private static final String DCR_RESPONSE = "{\"client_id\": \"client-id-123\"}\n";
 
-	private static MockedStatic<ClientRegistrations> clientRegistrationsMock;
-
 	private final McpClientRegistrationRepository repository = new InMemoryMcpClientRegistrationRepository();
 
 	private final DynamicClientRegistrationService clientRegistrationService = mock(
@@ -86,25 +80,6 @@ class DefaultMcpOAuth2DcrClientManagerTests {
 
 	private final DefaultMcpOAuth2DcrClientManager manager = new DefaultMcpOAuth2DcrClientManager(this.repository,
 			this.clientRegistrationService, this.discovery, this.urlValidator);
-
-	@BeforeAll
-	static void beforeAll() {
-		DefaultMcpOAuth2DcrClientManagerTests.clientRegistrationsMock = mockStatic(ClientRegistrations.class);
-		clientRegistrationsMock.when(() -> ClientRegistrations.fromIssuerLocation(ISSUER_URL))
-			.thenReturn(ClientRegistration.withRegistrationId("placeholder")
-				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-				.clientId("placeholder")
-				.tokenUri(ISSUER_URL + "/oauth2/token")
-				.authorizationUri(ISSUER_URL + "/oauth2/authorize")
-				.providerConfigurationMetadata(Map.of("token_endpoint", ISSUER_URL + "/oauth2/token",
-						"authorization_endpoint", ISSUER_URL + "/oauth2/authorize")));
-
-	}
-
-	@AfterAll
-	static void afterAll() {
-		DefaultMcpOAuth2DcrClientManagerTests.clientRegistrationsMock.close();
-	}
 
 	@Nested
 	class RegisterMcpClientWithDiscovery {
@@ -197,6 +172,56 @@ class DefaultMcpOAuth2DcrClientManagerTests {
 		}
 
 		@Test
+		@DisplayName("Requests offline access when enabled and supported by the authorization server")
+		void requestsOfflineAccessWhenEnabledAndSupported() {
+			var wwwAuthParams = WwwAuthenticateParameters.parse(
+					"Bearer resource_metadata=\"https://mcp.example.com/.well-known/oauth-protected-resource\", scope=\"mcp:read\"");
+			var prm = new ProtectedResourceMetadata(RESOURCE_ID, List.of(ISSUER_URL), null);
+			configureMocks(wwwAuthParams, prm, DCR_RESPONSE);
+			var manager = new DefaultMcpOAuth2DcrClientManager(repository, clientRegistrationService, discovery,
+					urlValidator, true);
+			var request = DynamicClientRegistrationRequest.builder()
+				.grantTypes(List.of(AuthorizationGrantType.AUTHORIZATION_CODE))
+				.redirectUris(List.of("https://client.example.com/callback"))
+				.build();
+
+			manager.registerMcpClient(REGISTRATION_ID, MCP_SERVER_URL, request);
+
+			var requestCaptor = ArgumentCaptor.forClass(DynamicClientRegistrationRequest.class);
+			verify(clientRegistrationService).register(requestCaptor.capture(), any(ClientRegistration.class));
+			verify(clientRegistrationService).getAuthorizationServerMetadata(ISSUER_URL);
+			assertThat(requestCaptor.getValue().getGrantTypes()).containsExactly("authorization_code", "refresh_token");
+			assertThat(requestCaptor.getValue().getScope()).isEqualTo("mcp:read offline_access");
+			var registration = repository.findByRegistrationId(REGISTRATION_ID);
+			assertThat(registration).isNotNull();
+			assertThat(registration.getScopes()).containsExactly("mcp:read", "offline_access");
+		}
+
+		@Test
+		@DisplayName("Does not request offline access when unsupported by the authorization server")
+		void doesNotRequestOfflineAccessWhenUnsupported() {
+			var wwwAuthParams = WwwAuthenticateParameters.parse(
+					"Bearer resource_metadata=\"https://mcp.example.com/.well-known/oauth-protected-resource\", scope=\"mcp:read\"");
+			var prm = new ProtectedResourceMetadata(RESOURCE_ID, List.of(ISSUER_URL), null);
+			configureMocks(wwwAuthParams, prm, DCR_RESPONSE);
+			when(clientRegistrationService.getAuthorizationServerMetadata(ISSUER_URL))
+				.thenReturn(authorizationServerMetadata(List.of("mcp:read")));
+			var manager = new DefaultMcpOAuth2DcrClientManager(repository, clientRegistrationService, discovery,
+					urlValidator, true);
+			var request = DynamicClientRegistrationRequest.builder()
+				.grantTypes(List.of(AuthorizationGrantType.AUTHORIZATION_CODE))
+				.redirectUris(List.of("https://client.example.com/callback"))
+				.build();
+
+			manager.registerMcpClient(REGISTRATION_ID, MCP_SERVER_URL, request);
+
+			var requestCaptor = ArgumentCaptor.forClass(DynamicClientRegistrationRequest.class);
+			verify(clientRegistrationService).register(requestCaptor.capture(), any(ClientRegistration.class));
+			assertThat(requestCaptor.getValue().getGrantTypes()).containsExactly("authorization_code");
+			assertThat(requestCaptor.getValue().getScope()).isEqualTo("mcp:read");
+		}
+
+		@Test
 		@DisplayName("Throws when configuration metadata contains invalid URL")
 		void throwsWhenConfigurationMetadataContainsInvalidUrl() throws InvalidUrlException {
 			var wwwAuthParams = WwwAuthenticateParameters
@@ -218,7 +243,10 @@ class DefaultMcpOAuth2DcrClientManagerTests {
 			var mcpMetadata = new McpMetadata(wwwAuthParams, protectedResourceMetadata);
 			when(discovery.getMcpMetadata(MCP_SERVER_URL, wwwAuthParams)).thenReturn(mcpMetadata);
 			var registrationResponse = dcrResponse(dcrResponse);
-			when(clientRegistrationService.register(any(), eq(ISSUER_URL))).thenReturn(registrationResponse);
+			when(clientRegistrationService.getAuthorizationServerMetadata(ISSUER_URL))
+				.thenReturn(authorizationServerMetadata(List.of("mcp:read", "offline_access")));
+			when(clientRegistrationService.register(any(), any(ClientRegistration.class)))
+				.thenReturn(registrationResponse);
 		}
 
 	}
@@ -256,7 +284,10 @@ class DefaultMcpOAuth2DcrClientManagerTests {
 						"scope": "openid profile"
 					}
 					""");
-			when(clientRegistrationService.register(any(), eq(ISSUER_URL))).thenReturn(registrationResponse);
+			when(clientRegistrationService.getAuthorizationServerMetadata(ISSUER_URL))
+				.thenReturn(authorizationServerMetadata(List.of("mcp:read", "offline_access")));
+			when(clientRegistrationService.register(any(), any(ClientRegistration.class)))
+				.thenReturn(registrationResponse);
 
 			manager.registerMcpClient(REGISTRATION_ID, MCP_SERVER_URL, WWW_AUTHENTICATE_HEADER,
 					DynamicClientRegistrationRequest.builder().build());
@@ -387,7 +418,10 @@ class DefaultMcpOAuth2DcrClientManagerTests {
 			var mcpMetadata = new McpMetadata(null, prm);
 			when(discovery.getMcpMetadata(eq(MCP_SERVER_URL), any())).thenReturn(mcpMetadata);
 			var registrationResponse = dcrResponse(dcrResponse);
-			when(clientRegistrationService.register(any(), eq(ISSUER_URL))).thenReturn(registrationResponse);
+			when(clientRegistrationService.getAuthorizationServerMetadata(ISSUER_URL))
+				.thenReturn(authorizationServerMetadata(List.of("mcp:read", "offline_access")));
+			when(clientRegistrationService.register(any(), any(ClientRegistration.class)))
+				.thenReturn(registrationResponse);
 		}
 
 	}
@@ -397,6 +431,19 @@ class DefaultMcpOAuth2DcrClientManagerTests {
 			.propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
 			.build()
 			.readValue(json, DynamicClientRegistrationResponse.class);
+	}
+
+	private static ClientRegistration authorizationServerMetadata(List<String> scopesSupported) {
+		return ClientRegistration.withRegistrationId("placeholder")
+			.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+			.clientId("placeholder")
+			.tokenUri(ISSUER_URL + "/oauth2/token")
+			.authorizationUri(ISSUER_URL + "/oauth2/authorize")
+			.issuerUri(ISSUER_URL)
+			.providerConfigurationMetadata(Map.of("token_endpoint", ISSUER_URL + "/oauth2/token",
+					"authorization_endpoint", ISSUER_URL + "/oauth2/authorize", "registration_endpoint",
+					ISSUER_URL + "/connect/register", "scopes_supported", scopesSupported))
+			.build();
 	}
 
 }


### PR DESCRIPTION
## Summary

Adds opt-in support for requesting refresh tokens in accordance with SEP-2207.

- Adds the `request-offline-access` client configuration property
- Requests `offline_access` only when advertised by the authorization server
- Includes `refresh_token` in DCR grant types for eligible authorization-code clients
- Preserves existing resource and explicitly configured scopes
- Documents the new configuration
- Adds focused test coverage

## Configuration

```
spring.ai.mcp.client.authorization.dynamic-client-registration.request-offline-access=true
```

The option is disabled by default.

## Testing

```shell
./mvnw -pl mcp-client-security,mcp-client-security-spring-boot -am test
```

Closes #86.