### PR TITLE
Add multi-tenant MCP server security

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,52 @@ class McpServerConfiguration {
 }
 ```
 
+### Multi-tenant OAuth2 resource servers
+
+For authorization servers that use a different issuer for each tenant, configure the lower-level
+`mcp-server-security` module manually. Supply Spring Security's tenant-aware
+`AuthenticationManagerResolver<HttpServletRequest>` and advertise every trusted issuer in the protected resource
+metadata:
+
+```java
+
+@Configuration
+@EnableWebSecurity
+class McpServerConfiguration {
+
+    private static final List<String> TRUSTED_ISSUERS = List.of(
+            "https://keycloak.example.com/realms/tenant-a",
+            "https://keycloak.example.com/realms/tenant-b"
+    );
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) {
+        var authenticationManagerResolver =
+                JwtIssuerAuthenticationManagerResolver.fromTrustedIssuers(TRUSTED_ISSUERS);
+
+        return http
+                .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .with(
+                        McpServerOAuth2Configurer.mcpServerOAuth2(),
+                        (mcpAuthorization) -> mcpAuthorization
+                                .authorizationServers(TRUSTED_ISSUERS)
+                                .authenticationManagerResolver(authenticationManagerResolver)
+                )
+                .build();
+    }
+}
+```
+
+Only explicitly trusted issuers should be accepted. Using an unrestricted issuer predicate would allow arbitrary
+issuers to make the server contact attacker-controlled authorization-server endpoints.
+
+If the application already has a tenant-aware `JwtDecoder`—for example, one backed by a
+`JWTClaimsSetAwareJWSKeySelector`—pass it to `.jwtDecoder(...)` instead of configuring an
+`AuthenticationManagerResolver`.
+
+The `mcp-server-security-spring-boot` auto-configuration remains intended for the single-issuer case. Defining the
+`SecurityFilterChain` above makes Boot back off from its default security configuration.
+
 ### Special case: only secure tool calls with OAuth2
 
 It is also possible to secure the tools only, and not the rest of the MCP Server. For example, both `initialize` and

--- a/mcp-server-security/src/main/java/org/springaicommunity/mcp/security/server/config/McpServerOAuth2Configurer.java
+++ b/mcp-server-security/src/main/java/org/springaicommunity/mcp/security/server/config/McpServerOAuth2Configurer.java
@@ -18,7 +18,10 @@ package org.springaicommunity.mcp.security.server.config;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.jspecify.annotations.Nullable;
 import org.springaicommunity.mcp.security.server.oauth2.authentication.BearerResourceMetadataTokenAuthenticationEntryPoint;
@@ -26,6 +29,7 @@ import org.springaicommunity.mcp.security.server.oauth2.jwt.AudienceValidationJw
 import org.springaicommunity.mcp.security.server.oauth2.metadata.ResourceIdentifier;
 import org.springaicommunity.mcp.security.server.web.OriginValidationFilter;
 
+import org.springframework.security.authentication.AuthenticationManagerResolver;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -46,6 +50,10 @@ import org.springframework.web.filter.CorsFilter;
 public class McpServerOAuth2Configurer extends AbstractHttpConfigurer<McpServerOAuth2Configurer, HttpSecurity> {
 
 	public @Nullable String issuerUri = null;
+
+	public @Nullable List<String> authorizationServers = null;
+
+	public @Nullable AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver = null;
 
 	private String resourceName = "Spring MCP Resource Server";
 
@@ -68,6 +76,20 @@ public class McpServerOAuth2Configurer extends AbstractHttpConfigurer<McpServerO
 
 	public McpServerOAuth2Configurer authorizationServer(String issuerUri) {
 		this.issuerUri = issuerUri;
+		this.authorizationServers = List.of(issuerUri);
+		return this;
+	}
+
+	public McpServerOAuth2Configurer authorizationServers(List<String> authorizationServers) {
+		Assert.notEmpty(authorizationServers, "authorizationServers cannot be empty");
+		this.authorizationServers = List.copyOf(authorizationServers);
+		return this;
+	}
+
+	public McpServerOAuth2Configurer authenticationManagerResolver(
+			AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver) {
+		Assert.notNull(authenticationManagerResolver, "authenticationManagerResolver cannot be null");
+		this.authenticationManagerResolver = authenticationManagerResolver;
 		return this;
 	}
 
@@ -163,17 +185,26 @@ public class McpServerOAuth2Configurer extends AbstractHttpConfigurer<McpServerO
 
 	@Override
 	public void init(HttpSecurity http) {
-		Assert.notNull(this.issuerUri, "authorizationServer cannot be null");
+		var authorizationServers = Objects.requireNonNull(this.authorizationServers,
+				"authorizationServers cannot be null");
+		Assert.notEmpty(authorizationServers, "authorizationServers cannot be empty");
+		Assert.isTrue(this.issuerUri != null || this.jwtDecoder != null || this.authenticationManagerResolver != null,
+				"authorizationServer, jwtDecoder, or authenticationManagerResolver must be configured");
 		Assert.notNull(this.resourceIdentifier, "resourceIdentifier cannot be null");
-		var issuerUri = this.issuerUri;
+		var authenticationManagerResolver = this.authenticationManagerResolver;
 
 		var entryPoint = new BearerResourceMetadataTokenAuthenticationEntryPoint(this.resourceIdentifier);
 
 		http.oauth2ResourceServer(resourceServer -> {
-			resourceServer.jwt(jwt -> jwt.decoder(getJwtDecoder(issuerUri)));
+			if (authenticationManagerResolver != null) {
+				resourceServer.authenticationManagerResolver(authenticationManagerResolver);
+			}
+			else {
+				resourceServer.jwt(jwt -> jwt.decoder(getJwtDecoder(this.issuerUri)));
+			}
 			resourceServer.authenticationEntryPoint(entryPoint);
 			resourceServer.protectedResourceMetadata(protectedResource -> protectedResource
-				.protectedResourceMetadataCustomizer(getProtectedMetadataCustomizer(issuerUri)));
+				.protectedResourceMetadataCustomizer(getProtectedMetadataCustomizer(authorizationServers)));
 			this.oauth2ResourceServerCustomizer.customize(resourceServer);
 		});
 		if (this.sessionBindingConfigurer != null) {
@@ -187,9 +218,12 @@ public class McpServerOAuth2Configurer extends AbstractHttpConfigurer<McpServerO
 		}
 	}
 
-	private JwtDecoder getJwtDecoder(String issuerUri) {
-		var rawDecoder = this.jwtDecoder != null ? this.jwtDecoder
-				: NimbusJwtDecoder.withIssuerLocation(issuerUri).build();
+	private JwtDecoder getJwtDecoder(@Nullable String issuerUri) {
+		var rawDecoder = this.jwtDecoder;
+		if (rawDecoder == null) {
+			Assert.notNull(issuerUri, "authorizationServer cannot be null when jwtDecoder is not configured");
+			rawDecoder = NimbusJwtDecoder.withIssuerLocation(issuerUri).build();
+		}
 
 		if (this.validateAudienceClaim) {
 			return new AudienceValidationJwtDecoder(rawDecoder, this.resourceIdentifier);
@@ -198,11 +232,14 @@ public class McpServerOAuth2Configurer extends AbstractHttpConfigurer<McpServerO
 		return rawDecoder;
 	}
 
-	private Consumer<OAuth2ProtectedResourceMetadata.Builder> getProtectedMetadataCustomizer(String issuerUri) {
+	private Consumer<OAuth2ProtectedResourceMetadata.Builder> getProtectedMetadataCustomizer(
+			List<String> authorizationServers) {
 		if (this.customizer != null) {
 			return this.customizer;
 		}
-		return (protectedMetadata) -> protectedMetadata.authorizationServer(issuerUri).resourceName(this.resourceName);
+		return (protectedMetadata) -> protectedMetadata
+			.authorizationServers((servers) -> servers.addAll(authorizationServers))
+			.resourceName(this.resourceName);
 	}
 
 	public static McpServerOAuth2Configurer mcpServerOAuth2() {

--- a/mcp-server-security/src/test/java/org/springaicommunity/mcp/security/server/config/McpServerOAuth2ConfigurerTests.java
+++ b/mcp-server-security/src/test/java/org/springaicommunity/mcp/security/server/config/McpServerOAuth2ConfigurerTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.server.config;
+
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class McpServerOAuth2ConfigurerTests {
+
+	@Test
+	void authorizationServerConfiguresSingleIssuer() {
+		var configurer = new McpServerOAuth2Configurer().authorizationServer("https://issuer.example.com");
+
+		assertThat(configurer.issuerUri).isEqualTo("https://issuer.example.com");
+		assertThat(configurer.authorizationServers).containsExactly("https://issuer.example.com");
+	}
+
+	@Test
+	void configuresMultipleAuthorizationServersAndAuthenticationManagerResolver() {
+		AuthenticationManagerResolver<HttpServletRequest> resolver = mock();
+		var configurer = new McpServerOAuth2Configurer()
+			.authorizationServers(List.of("https://keycloak.example.com/realms/tenant-a",
+					"https://keycloak.example.com/realms/tenant-b"))
+			.authenticationManagerResolver(resolver);
+
+		assertThat(configurer.authorizationServers).containsExactly("https://keycloak.example.com/realms/tenant-a",
+				"https://keycloak.example.com/realms/tenant-b");
+		assertThat(configurer.authenticationManagerResolver).isSameAs(resolver);
+		assertThat(configurer.issuerUri).isNull();
+	}
+
+	@Test
+	void configuresMultipleAuthorizationServersAndTenantAwareJwtDecoder() {
+		var jwtDecoder = mock(JwtDecoder.class);
+		var configurer = new McpServerOAuth2Configurer()
+			.authorizationServers(List.of("https://keycloak.example.com/realms/tenant-a",
+					"https://keycloak.example.com/realms/tenant-b"))
+			.jwtDecoder(jwtDecoder);
+
+		assertThat(configurer.authorizationServers).hasSize(2);
+		assertThat(configurer.jwtDecoder).isSameAs(jwtDecoder);
+		assertThat(configurer.issuerUri).isNull();
+	}
+
+}


### PR DESCRIPTION
## Summary

Adds multi-tenant OAuth2 support for MCP resource servers where each tenant has a distinct issuer, such as a Keycloak realm-per-tenant deployment.

Fixes #97.

## Changes

- Add `authorizationServers(List<String>)` to advertise multiple trusted issuers through OAuth2 Protected Resource Metadata.
- Add support for Spring Security’s `AuthenticationManagerResolver<HttpServletRequest>` for tenant-aware authentication.
- Allow an existing tenant-aware `JwtDecoder`, including implementations backed by `JWTClaimsSetAwareJWSKeySelector`.
- Preserve the existing `authorizationServer(String)` single-issuer configuration.
- Document multi-tenant configuration with `JwtIssuerAuthenticationManagerResolver`.
- Add tests covering single-issuer and multi-tenant configuration.

## Security considerations

The documentation recommends explicitly trusted issuers. Accepting arbitrary issuers could cause the resource server to contact attacker-controlled authorization-server endpoints.

## Testing

```text
./mvnw -pl mcp-server-security -am test

Tests run: 88, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```