### PR TITLE
fix: support at+jwt access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:9000
 
 That's it. When `spring.security.oauth2.resourceserver.jwt.issuer-uri` is set, the auto-configuration
 creates a `SecurityFilterChain` that secures all endpoints using the `McpServerOAuth2Configurer`.
+The default JWT decoder accepts access tokens with a `typ` header of either `JWT` or `at+jwt`, as well as tokens
+without a `typ` header.
 
 For a complete working example, see the
 [sample-mcp-server](https://github.com/spring-ai-community/mcp-security/tree/main/samples/sample-mcp-server) module.

--- a/mcp-server-security/src/main/java/org/springaicommunity/mcp/security/server/config/McpServerOAuth2Configurer.java
+++ b/mcp-server-security/src/main/java/org/springaicommunity/mcp/security/server/config/McpServerOAuth2Configurer.java
@@ -30,7 +30,12 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
+import org.springframework.security.oauth2.jwt.JwtTypeValidator;
+import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.OAuth2ProtectedResourceMetadata;
 import org.springframework.util.Assert;
@@ -188,14 +193,25 @@ public class McpServerOAuth2Configurer extends AbstractHttpConfigurer<McpServerO
 	}
 
 	private JwtDecoder getJwtDecoder(String issuerUri) {
-		var rawDecoder = this.jwtDecoder != null ? this.jwtDecoder
-				: NimbusJwtDecoder.withIssuerLocation(issuerUri).build();
+		var rawDecoder = this.jwtDecoder != null ? this.jwtDecoder : createJwtDecoder(issuerUri);
 
 		if (this.validateAudienceClaim) {
 			return new AudienceValidationJwtDecoder(rawDecoder, this.resourceIdentifier);
 		}
 
 		return rawDecoder;
+	}
+
+	private static JwtDecoder createJwtDecoder(String issuerUri) {
+		var decoder = NimbusJwtDecoder.withIssuerLocation(issuerUri).validateType(false).build();
+		decoder.setJwtValidator(createJwtValidator(issuerUri));
+		return decoder;
+	}
+
+	static OAuth2TokenValidator<Jwt> createJwtValidator(String issuerUri) {
+		var typeValidator = new JwtTypeValidator("JWT", "at+jwt");
+		typeValidator.setAllowEmpty(true);
+		return JwtValidators.createDefaultWithValidators(new JwtIssuerValidator(issuerUri), typeValidator);
 	}
 
 	private Consumer<OAuth2ProtectedResourceMetadata.Builder> getProtectedMetadataCustomizer(String issuerUri) {

--- a/mcp-server-security/src/test/java/org/springaicommunity/mcp/security/server/config/McpServerOAuth2ConfigurerTests.java
+++ b/mcp-server-security/src/test/java/org/springaicommunity/mcp/security/server/config/McpServerOAuth2ConfigurerTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.server.config;
+
+import java.time.Instant;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpServerOAuth2ConfigurerTests {
+
+	private static final String ISSUER = "https://example.com";
+
+	@Test
+	void acceptsJwtTokenType() {
+		var result = McpServerOAuth2Configurer.createJwtValidator(ISSUER).validate(jwt("JWT"));
+
+		assertThat(result.hasErrors()).isFalse();
+	}
+
+	@Test
+	void acceptsAtJwtTokenType() {
+		var result = McpServerOAuth2Configurer.createJwtValidator(ISSUER).validate(jwt("at+jwt"));
+
+		assertThat(result.hasErrors()).isFalse();
+	}
+
+	@Test
+	void acceptsMissingTokenType() {
+		var result = McpServerOAuth2Configurer.createJwtValidator(ISSUER).validate(jwt(null));
+
+		assertThat(result.hasErrors()).isFalse();
+	}
+
+	@Test
+	void rejectsUnsupportedTokenType() {
+		var result = McpServerOAuth2Configurer.createJwtValidator(ISSUER).validate(jwt("unsupported+jwt"));
+
+		assertThat(result.hasErrors()).isTrue();
+	}
+
+	private static Jwt jwt(@Nullable String type) {
+		var now = Instant.now();
+		var builder = Jwt.withTokenValue("token")
+			.issuedAt(now.minusSeconds(60))
+			.expiresAt(now.plusSeconds(60))
+			.issuer(ISSUER)
+			.header("kid", "key-id");
+		if (type != null) {
+			builder.header("typ", type);
+		}
+		return builder.build();
+	}
+
+}


### PR DESCRIPTION
## Summary

Adds support for OAuth access tokens with the `at+jwt` JOSE `typ` header.

Fixes #96.

## Changes

- Configure the default JWT decoder to accept:
  - `JWT`
  - `at+jwt`
  - Tokens without a `typ` header
- Continue rejecting unsupported token types.
- Preserve issuer, timestamp, and certificate-thumbprint validation.
- Leave user-provided `JwtDecoder` instances unchanged.
- Document the supported token types.
- Add focused unit tests for accepted and rejected token types.

## Testing

```text
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Command:

```bash
./mvnw -pl mcp-server-security -am \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dtest=McpServerOAuth2ConfigurerTests test
```