### PR TITLE
Authorization Server: support refresh tokens for public clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1177,6 +1177,35 @@ SecurityFilterChain securityFilterChain(HttpSecurity http) {
 }
 ```
 
+### Public client refresh tokens
+
+Spring Authorization Server does not issue refresh tokens to public clients by default. You can opt in to issuing
+and accepting refresh tokens for public clients. The client must also be registered with the `refresh_token` grant
+type.
+
+If you are using the Boot auto-configuration, enable support with the following property:
+
+```properties
+spring.ai.mcp.authorizationserver.public-client-refresh-tokens.enabled=true
+```
+
+If you are configuring the server manually, enable it via the configurer:
+
+```java
+@Bean
+SecurityFilterChain securityFilterChain(HttpSecurity http) {
+    return http
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .with(McpAuthorizationServerConfigurer.mcpAuthorizationServer(), mcp -> {
+                mcp.publicClientRefreshTokens(true);
+            })
+            .build();
+}
+```
+
+This option is disabled by default. Refresh tokens are long-lived credentials, so only enable it when your public
+clients can store them securely.
+
 ### Client ID Metadata Document (CIMD)
 
 CIMD is an alternative to DCR where the client identifies itself with a URL pointing to a metadata document

--- a/mcp-authorization-server-spring-boot/src/main/java/org/springaicommunity/mcp/security/authorizationserver/boot/McpAuthorizationServerAutoConfiguration.java
+++ b/mcp-authorization-server-spring-boot/src/main/java/org/springaicommunity/mcp/security/authorizationserver/boot/McpAuthorizationServerAutoConfiguration.java
@@ -74,6 +74,7 @@ class McpAuthorizationServerAutoConfiguration {
 		return http.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
 			.with(mcpAuthorizationServer(), mcp -> {
 				mcp.dynamicClientRegistration(properties.getDynamicClientRegistration().isEnabled());
+				mcp.publicClientRefreshTokens(properties.getPublicClientRefreshTokens().isEnabled());
 				mcpCustomizers.orderedStream().forEach(customizer -> customizer.customize(mcp));
 				mcp.authorizationServer(authzServer -> {
 					http.securityMatcher(new OrRequestMatcher(authzServer.getEndpointsMatcher(),

--- a/mcp-authorization-server-spring-boot/src/main/java/org/springaicommunity/mcp/security/authorizationserver/boot/McpOAuth2AuthorizationServerProperties.java
+++ b/mcp-authorization-server-spring-boot/src/main/java/org/springaicommunity/mcp/security/authorizationserver/boot/McpOAuth2AuthorizationServerProperties.java
@@ -28,6 +28,8 @@ class McpOAuth2AuthorizationServerProperties {
 
 	private DynamicClientRegistration dynamicClientRegistration = new DynamicClientRegistration();
 
+	private PublicClientRefreshTokens publicClientRefreshTokens = new PublicClientRefreshTokens();
+
 	public DynamicClientRegistration getDynamicClientRegistration() {
 		return dynamicClientRegistration;
 	}
@@ -36,12 +38,37 @@ class McpOAuth2AuthorizationServerProperties {
 		this.dynamicClientRegistration = dynamicClientRegistration;
 	}
 
+	public PublicClientRefreshTokens getPublicClientRefreshTokens() {
+		return publicClientRefreshTokens;
+	}
+
+	public void setPublicClientRefreshTokens(PublicClientRefreshTokens publicClientRefreshTokens) {
+		this.publicClientRefreshTokens = publicClientRefreshTokens;
+	}
+
 	public static class DynamicClientRegistration {
 
 		/**
 		 * Enable dynamic client registration.
 		 */
 		private boolean enabled = true;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+	}
+
+	public static class PublicClientRefreshTokens {
+
+		/**
+		 * Enable refresh token support for public clients.
+		 */
+		private boolean enabled = false;
 
 		public boolean isEnabled() {
 			return enabled;

--- a/mcp-authorization-server-spring-boot/src/test/java/org/springaicommunity/mcp/security/authorizationserver/boot/McpAuthorizationServerAutoConfigurationTests.java
+++ b/mcp-authorization-server-spring-boot/src/test/java/org/springaicommunity/mcp/security/authorizationserver/boot/McpAuthorizationServerAutoConfigurationTests.java
@@ -147,6 +147,13 @@ class McpAuthorizationServerAutoConfigurationTests {
 		});
 	}
 
+	@Test
+	void publicClientRefreshTokensCanBeEnabled() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.mcp.authorizationserver.public-client-refresh-tokens.enabled=true")
+			.run((context) -> assertThat(context).hasNotFailed());
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class CustomizerConfiguration {
 

--- a/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationServerConfigurer.java
+++ b/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/McpAuthorizationServerConfigurer.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import com.nimbusds.jose.jwk.source.JWKSource;
@@ -42,6 +43,7 @@ import org.springframework.security.oauth2.server.authorization.authentication.O
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationValidator;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientRegistrationAuthenticationContext;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientRegistrationAuthenticationValidator;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.mcp.token.ResourceIdentifierAudienceTokenCustomizer;
 import org.springframework.security.oauth2.server.authorization.token.DelegatingOAuth2TokenGenerator;
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
@@ -69,6 +71,8 @@ public class McpAuthorizationServerConfigurer
 	private boolean supportDynamicClientRegistration = true;
 
 	private boolean supportClientIdMetadataDocument = false;
+
+	private boolean supportPublicClientRefreshTokens = false;
 
 	private Consumer<OAuth2ClientRegistrationAuthenticationContext> clientRegistrationValidator = new OAuth2ClientRegistrationAuthenticationValidator();
 
@@ -114,6 +118,17 @@ public class McpAuthorizationServerConfigurer
 	}
 
 	/**
+	 * Enable or disable refresh token support for public clients.
+	 * @param enabled issue and accept refresh tokens for public clients when true.
+	 * Defaults to false.
+	 * @return The {@link McpAuthorizationServerConfigurer} for further configuration.
+	 */
+	public McpAuthorizationServerConfigurer publicClientRefreshTokens(boolean enabled) {
+		this.supportPublicClientRefreshTokens = enabled;
+		return this;
+	}
+
+	/**
 	 * Update the validator for incoming client registrations.
 	 * @param clientRegistrationValidator the validator. Defaults to
 	 * {@link OAuth2ClientRegistrationAuthenticationValidator};
@@ -146,6 +161,15 @@ public class McpAuthorizationServerConfigurer
 				authz.withObjectPostProcessor(McpOpenClientRegistryAuthorizationManager.postProcessor());
 			}
 		}).oauth2AuthorizationServer(authServer -> {
+			if (this.supportPublicClientRefreshTokens) {
+				RegisteredClientRepository registeredClientRepository = Objects.requireNonNull(
+						getOptionalBean(http, RegisteredClientRepository.class),
+						"registeredClientRepository cannot be null");
+				authServer.clientAuthentication(clientAuthentication -> clientAuthentication
+					.authenticationConverter(new PublicClientRefreshTokenAuthenticationConverter())
+					.authenticationProvider(
+							new PublicClientRefreshTokenAuthenticationProvider(registeredClientRepository)));
+			}
 			authServer.addObjectPostProcessor(McpNoScopeClientConsentNotRequired.postProcessor());
 			authServer.addObjectPostProcessor(
 					new McpAuthorizationCodeRequestValidatorPostProcessor(this.authorizationCodeRequestValidator));
@@ -158,6 +182,11 @@ public class McpAuthorizationServerConfigurer
 				}
 			});
 			OAuth2TokenGenerator<?> tokenGenerator = getTokenGenerator(http);
+			if (this.supportPublicClientRefreshTokens) {
+				tokenGenerator = new DelegatingOAuth2TokenGenerator(tokenGenerator,
+						new PublicClientRefreshTokenGenerator());
+				http.setSharedObject(OAuth2TokenGenerator.class, tokenGenerator);
+			}
 			authServer.tokenGenerator(tokenGenerator);
 			if (this.supportDynamicClientRegistration) {
 				authServer.clientRegistrationEndpoint(cr -> cr.openRegistrationAllowed(true));

--- a/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/PublicClientRefreshTokenAuthenticationConverter.java
+++ b/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/PublicClientRefreshTokenAuthenticationConverter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.authorizationserver.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.util.StringUtils;
+
+final class PublicClientRefreshTokenAuthenticationConverter implements AuthenticationConverter {
+
+	@Override
+	public @Nullable Authentication convert(HttpServletRequest request) {
+		String grantType = request.getParameter(OAuth2ParameterNames.GRANT_TYPE);
+		if (!AuthorizationGrantType.REFRESH_TOKEN.getValue().equals(grantType)) {
+			return null;
+		}
+
+		String clientId = request.getParameter(OAuth2ParameterNames.CLIENT_ID);
+		if (!StringUtils.hasText(clientId)) {
+			return null;
+		}
+
+		return new PublicClientRefreshTokenAuthenticationToken(clientId);
+	}
+
+}

--- a/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/PublicClientRefreshTokenAuthenticationProvider.java
+++ b/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/PublicClientRefreshTokenAuthenticationProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.authorizationserver.config;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.util.Assert;
+
+final class PublicClientRefreshTokenAuthenticationProvider implements AuthenticationProvider {
+
+	private final RegisteredClientRepository registeredClientRepository;
+
+	PublicClientRefreshTokenAuthenticationProvider(RegisteredClientRepository registeredClientRepository) {
+		Assert.notNull(registeredClientRepository, "registeredClientRepository cannot be null");
+		this.registeredClientRepository = registeredClientRepository;
+	}
+
+	@Override
+	public @Nullable Authentication authenticate(Authentication authentication) throws AuthenticationException {
+		PublicClientRefreshTokenAuthenticationToken clientAuthentication = (PublicClientRefreshTokenAuthenticationToken) authentication;
+		if (!ClientAuthenticationMethod.NONE.equals(clientAuthentication.getClientAuthenticationMethod())) {
+			return null;
+		}
+
+		String clientId = clientAuthentication.getPrincipal().toString();
+		RegisteredClient registeredClient = this.registeredClientRepository.findByClientId(clientId);
+		if (registeredClient == null) {
+			throw invalidClient(OAuth2ParameterNames.CLIENT_ID);
+		}
+		if (!registeredClient.getClientAuthenticationMethods()
+			.contains(clientAuthentication.getClientAuthenticationMethod())) {
+			throw invalidClient("authentication_method");
+		}
+
+		return new PublicClientRefreshTokenAuthenticationToken(registeredClient);
+	}
+
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return PublicClientRefreshTokenAuthenticationToken.class.isAssignableFrom(authentication);
+	}
+
+	private static OAuth2AuthenticationException invalidClient(String parameterName) {
+		OAuth2Error error = new OAuth2Error(OAuth2ErrorCodes.INVALID_CLIENT,
+				"Public client authentication failed: " + parameterName, null);
+		return new OAuth2AuthenticationException(error);
+	}
+
+}

--- a/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/PublicClientRefreshTokenAuthenticationToken.java
+++ b/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/PublicClientRefreshTokenAuthenticationToken.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.authorizationserver.config;
+
+import org.springframework.security.core.Transient;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+
+@Transient
+final class PublicClientRefreshTokenAuthenticationToken extends OAuth2ClientAuthenticationToken {
+
+	PublicClientRefreshTokenAuthenticationToken(String clientId) {
+		super(clientId, ClientAuthenticationMethod.NONE, null, null);
+	}
+
+	PublicClientRefreshTokenAuthenticationToken(RegisteredClient registeredClient) {
+		super(registeredClient, ClientAuthenticationMethod.NONE, null);
+	}
+
+}

--- a/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/PublicClientRefreshTokenGenerator.java
+++ b/mcp-authorization-server/src/main/java/org/springaicommunity/mcp/security/authorizationserver/config/PublicClientRefreshTokenGenerator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.authorizationserver.config;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Base64;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.security.crypto.keygen.Base64StringKeyGenerator;
+import org.springframework.security.crypto.keygen.StringKeyGenerator;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
+import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenContext;
+import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenGenerator;
+
+final class PublicClientRefreshTokenGenerator implements OAuth2TokenGenerator<OAuth2RefreshToken> {
+
+	private final StringKeyGenerator refreshTokenGenerator = new Base64StringKeyGenerator(
+			Base64.getUrlEncoder().withoutPadding(), 96);
+
+	private final Clock clock = Clock.systemUTC();
+
+	@Override
+	public @Nullable OAuth2RefreshToken generate(OAuth2TokenContext context) {
+		Authentication authorizationGrant = context.getAuthorizationGrant();
+		if (!OAuth2TokenType.REFRESH_TOKEN.equals(context.getTokenType())
+				|| !AuthorizationGrantType.AUTHORIZATION_CODE.equals(context.getAuthorizationGrantType())
+				|| authorizationGrant == null
+				|| !(authorizationGrant.getPrincipal() instanceof OAuth2ClientAuthenticationToken client)
+				|| !ClientAuthenticationMethod.NONE.equals(client.getClientAuthenticationMethod())) {
+			return null;
+		}
+
+		Instant issuedAt = this.clock.instant();
+		Instant expiresAt = issuedAt.plus(context.getRegisteredClient().getTokenSettings().getRefreshTokenTimeToLive());
+		return new OAuth2RefreshToken(this.refreshTokenGenerator.generateKey(), issuedAt, expiresAt);
+	}
+
+}

--- a/mcp-authorization-server/src/test/java/org/springaicommunity/mcp/security/authorizationserver/config/PublicClientRefreshTokenSupportTests.java
+++ b/mcp-authorization-server/src/test/java/org/springaicommunity/mcp/security/authorizationserver/config/PublicClientRefreshTokenSupportTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.mcp.security.authorizationserver.config;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
+import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PublicClientRefreshTokenSupportTests {
+
+	@Test
+	void converterAcceptsPublicClientRefreshTokenRequest() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter(OAuth2ParameterNames.GRANT_TYPE, AuthorizationGrantType.REFRESH_TOKEN.getValue());
+		request.setParameter(OAuth2ParameterNames.CLIENT_ID, "public-client");
+
+		PublicClientRefreshTokenAuthenticationToken authentication = Objects.requireNonNull(
+				(PublicClientRefreshTokenAuthenticationToken) new PublicClientRefreshTokenAuthenticationConverter()
+					.convert(request));
+
+		assertThat(authentication).isNotNull();
+		assertThat(authentication.getPrincipal()).isEqualTo("public-client");
+		assertThat(authentication.getClientAuthenticationMethod()).isEqualTo(ClientAuthenticationMethod.NONE);
+	}
+
+	@Test
+	void providerAuthenticatesRegisteredPublicClient() {
+		RegisteredClient registeredClient = publicClient();
+		var repository = new InMemoryRegisteredClientRepository(registeredClient);
+		var provider = new PublicClientRefreshTokenAuthenticationProvider(repository);
+		var unauthenticated = new PublicClientRefreshTokenAuthenticationToken(registeredClient.getClientId());
+
+		PublicClientRefreshTokenAuthenticationToken authenticated = Objects
+			.requireNonNull((PublicClientRefreshTokenAuthenticationToken) provider.authenticate(unauthenticated));
+
+		assertThat(authenticated.isAuthenticated()).isTrue();
+		assertThat(authenticated.getRegisteredClient()).isEqualTo(registeredClient);
+	}
+
+	@Test
+	void generatorIssuesRefreshTokenForPublicAuthorizationCodeClient() {
+		RegisteredClient registeredClient = publicClient();
+		var clientAuthentication = new OAuth2ClientAuthenticationToken(registeredClient,
+				ClientAuthenticationMethod.NONE, null);
+		Authentication authorizationGrant = mock(Authentication.class);
+		when(authorizationGrant.getPrincipal()).thenReturn(clientAuthentication);
+		OAuth2TokenContext context = mock(OAuth2TokenContext.class);
+		when(context.getTokenType()).thenReturn(OAuth2TokenType.REFRESH_TOKEN);
+		when(context.getAuthorizationGrantType()).thenReturn(AuthorizationGrantType.AUTHORIZATION_CODE);
+		when(context.getAuthorizationGrant()).thenReturn(authorizationGrant);
+		when(context.getRegisteredClient()).thenReturn(registeredClient);
+
+		var refreshToken = Objects.requireNonNull(new PublicClientRefreshTokenGenerator().generate(context));
+
+		assertThat(refreshToken).isNotNull();
+		assertThat(refreshToken.getExpiresAt()).isAfter(refreshToken.getIssuedAt());
+	}
+
+	private static RegisteredClient publicClient() {
+		return RegisteredClient.withId(UUID.randomUUID().toString())
+			.clientId("public-client")
+			.clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+			.redirectUri("https://example.com/callback")
+			.build();
+	}
+
+}


### PR DESCRIPTION
## Summary

Add opt-in refresh token support for public OAuth 2.0 clients.

Spring Authorization Server does not issue refresh tokens to public clients by default and does not authenticate them during refresh-token requests. This change adds support for both parts of the flow.

## Changes

- Add `publicClientRefreshTokens(boolean)` to `McpAuthorizationServerConfigurer`.
- Add the Boot property:

  ```properties
  spring.ai.mcp.authorizationserver.public-client-refresh-tokens.enabled=true
  ```

- Generate refresh tokens for public authorization-code clients.
- Authenticate public clients during refresh-token requests.
- Preserve the existing PKCE validation path for authorization-code requests.
- Keep the feature disabled by default.
- Add focused unit and Boot configuration tests.
- Document configuration and security considerations.

## Testing


```bash
./mvnw -pl mcp-authorization-server -Dtest=PublicClientRefreshTokenSupportTests test
./mvnw -pl mcp-authorization-server-spring-boot -Dtest=McpAuthorizationServerAutoConfigurationTests test
```

Closes #85.